### PR TITLE
create helm chart for the authservice ui

### DIFF
--- a/_infra/helm/securebanking-ui/Chart.yaml
+++ b/_infra/helm/securebanking-ui/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: securebanking-ui
+description: A Helm chart for Kubernetes
+type: application
+version: 0.0.1
+appVersion: 0.0.1

--- a/_infra/helm/securebanking-ui/templates/auth-deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/auth-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: {{ .Values.apiVersion.deployment }}
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.auth.deployment.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.auth.deployment.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.auth.deployment.rollingUpdate.maxUnavailable }}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+        appVersion: {{ .Chart.AppVersion }}
+        helmVersion: {{ .Chart.Version }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- if .Values.auth.deployment.imageOverride.enabled }}
+          image: "{{ .Values.auth.deployment.imageOverride.repo }}:{{ .Values.auth.deployment.imageOverride.tag }}"
+          {{- else }}
+          image: "eu.gcr.io/sbat-gcr-release/securebanking/${ .Chart.Name }:{{ .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.auth.deployment.imagePullPolicy }}
+          ports:
+            - name: http-server
+              containerPort: {{ .Values.auth.deployment.port }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: {{ .Values.auth.deployment.port }}
+            periodSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: {{ .Values.auth.deployment.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.auth.deployment.resources | nindent 12 }}

--- a/_infra/helm/securebanking-ui/templates/auth-svc.yaml
+++ b/_infra/helm/securebanking-ui/templates/auth-svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: {{ .Values.apiVersion.service }}
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: {{ .Values.auth.deployment.port }}
+    protocol: TCP
+  selector:
+    app: {{ .Chart.Name }}

--- a/_infra/helm/securebanking-ui/values.yaml
+++ b/_infra/helm/securebanking-ui/values.yaml
@@ -1,0 +1,57 @@
+auth:
+  deployment:
+    port: 8080
+    replicas: 1
+
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 25%
+
+    imagePullPolicy: Always
+
+    imageOverride:
+      enabled: true
+      repo: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-ui/auth
+      tag: latest
+
+    resources: {}
+
+rcs:
+  deployment:
+    port: 8080
+    replicas: 1
+
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 25%
+
+    imagePullPolicy: Always
+
+    imageOverride:
+      enabled: true
+      repo: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-ui/rcs
+      tag: latest
+
+    resources: {}
+
+swagger:
+  deployment:
+    port: 8080
+    replicas: 1
+
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 25%
+
+    imagePullPolicy: Always
+
+    imageOverride:
+      enabled: true
+      repo: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-ui/swagger
+      tag: latest
+
+    resources: {}
+
+apiVersion:
+  service: v1
+  deployment: apps/v1


### PR DESCRIPTION
Create the Helm chart for the auth service UI.
Contains a deployment and service only. The ingress will be covered by IG.