### PR TITLE
apply auth service config

### DIFF
--- a/_infra/helm/securebanking-ui/templates/auth-deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/auth-deployment.yaml
@@ -34,7 +34,7 @@ spec:
               containerPort: {{ .Values.auth.deployment.port }}
           readinessProbe:
             httpGet:
-              path: /actuator/health
+              path: /dev/info
               port: {{ .Values.auth.deployment.port }}
             periodSeconds: 5
             failureThreshold: 3
@@ -42,12 +42,19 @@ spec:
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /actuator/health
+              path: /dev/info
               port: {{ .Values.auth.deployment.port }}
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 5
             successThreshold: 1
             timeoutSeconds: 5
+          env:
+            - name: DOMAIN
+              values: {{ .Values.domain }}
+            - name: AUTHENTICATION_URL
+              value: {{ .Values.authenticationUrl }}
+            - name: DIRECTORY_BACKEND_URL
+              value: {{ .Values.directoryBackendUrl }}
           resources:
             {{- toYaml .Values.auth.deployment.resources | nindent 12 }}

--- a/_infra/helm/securebanking-ui/values.yaml
+++ b/_infra/helm/securebanking-ui/values.yaml
@@ -1,3 +1,7 @@
+domain: dev.forgerock.financial
+authenticationUrl: https://auth.dev.forgerock.financial
+directoryBackendUrl: https://service.directory.dev.forgerock.financial/directory-services
+
 auth:
   deployment:
     port: 8080


### PR DESCRIPTION
Apply configuration for the auth ui. `DOMAIN`, `AUTHENTICATION_URL` and `DIRECTORY_BACKEND_URL` must be set.

Change the health check to `/dev/info`