### PR TITLE
Merge action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,42 @@
+name: merge-master
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - README.md
+
+env:
+  SERVICE_NAME: securebanking-ui
+
+jobs:
+  buildAuth:
+    runs-on: ubuntu-latest
+    name: Build auth image
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: test
+        run: |
+          make docker service=auth release-repo=${{ secrets.RELEASE_REPO}}
+
+  buildRcs:
+    runs-on: ubuntu-latest
+    name: Build rcs image
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: test
+        run: |
+          make docker service=rcs release-repo=${{ secrets.RELEASE_REPO}}
+  
+  buildSwagger:
+    runs-on: ubuntu-latest
+    name: Build swagger image
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: test
+        run: |
+          make docker service=swagger release-repo=${{ secrets.RELEASE_REPO}}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,9 +7,6 @@ on:
     paths-ignore:
       - README.md
 
-env:
-  SERVICE_NAME: securebanking-ui
-
 jobs:
   buildAuth:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,10 +66,7 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker tag=latest service=auth
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/auth:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/auth:${{ needs.pr.outputs.prTag }}
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/auth:${{ needs.pr.outputs.prTag }}
-          
+          make docker tag=${{ needs.pr.outputs.prTag }} service=auth
 
   rcs:
     runs-on: ubuntu-latest
@@ -112,9 +109,7 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker tag=latest service=rcs
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/rcs:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/rcs:${{ needs.pr.outputs.prTag }}
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/rcs:${{ needs.pr.outputs.prTag }}
+          make docker tag=${{ needs.pr.outputs.prTag }} service=rcs
 
   swagger:
     runs-on: ubuntu-latest
@@ -137,9 +132,7 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker tag=latest service=swagger
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/swagger:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/swagger:${{ needs.pr.outputs.prTag }}
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking-ui/swagger:${{ needs.pr.outputs.prTag }}
+          make docker tag=${{ needs.pr.outputs.prTag }} service=swagger
     
   helm:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 name := securebanking-ui
-dev-repo := sbat-gcr-develop
+gcr-repo := sbat-gcr-develop
 
 helm:
 ifndef version
@@ -19,4 +19,24 @@ ifndef tag
 	$(eval tag=latest)
 endif
 	cd securebanking-${service}-ui && \
-	docker build -t eu.gcr.io/${dev-repo}/securebanking-ui/${service}:${tag} -f projects/${service}/docker/Dockerfile .
+	docker build -t eu.gcr.io/${gcr-repo}/securebanking-ui/${service}:${tag} -f projects/${service}/docker/Dockerfile .
+	docker push eu.gcr.io/${gcr-repo}/securebanking-ui/${service}:${tag}
+ifdef release-repo
+	docker tag eu.gcr.io/${gcr-repo}/securebanking-ui/${service}:${tag} eu.gcr.io/${release-repo}/securebanking-ui/${service}:${tag}
+	docker push eu.gcr.io/${release-repo}/securebanking-ui/${service}:${tag}
+endif
+
+test:
+ifndef service
+	$(error A service must be supplied, one of auth, swagger or rcs, Eg. make docker service=auth)
+endif
+	cd securebanking-${service}-ui && \
+	npm ci
+	npm run test
+
+version:
+ifndef service
+	$(error A service must be supplied, one of auth, swagger or rcs, Eg. make docker service=auth)
+endif
+	cd securebanking-${service}-ui && \
+	npm -s run env echo '$$npm_package_version'


### PR DESCRIPTION
Add a merge action that executes the `make docker` target. Supplies the release repo to push to.
The `docker` target will push to dev repo and release repo if `release-repo` is supplied otherwise it will push to dev only.

Remove the `latest` tag from the pr action as outlined in https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/issues/54

Add a `version` target that will output the package.json version of the supplied ui.