### PR TITLE
remove the ui health checks

### DIFF
--- a/_infra/helm/securebanking-ui/templates/auth-deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/auth-deployment.yaml
@@ -32,23 +32,6 @@ spec:
           ports:
             - name: http-server
               containerPort: {{ .Values.auth.deployment.port }}
-          readinessProbe:
-            httpGet:
-              path: /dev/info
-              port: {{ .Values.auth.deployment.port }}
-            periodSeconds: 5
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 5
-          livenessProbe:
-            httpGet:
-              path: /dev/info
-              port: {{ .Values.auth.deployment.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 5
-            successThreshold: 1
-            timeoutSeconds: 5
           env:
             - name: DOMAIN
               value: {{ .Values.domain }}

--- a/_infra/helm/securebanking-ui/templates/rcs-deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/rcs-deployment.yaml
@@ -32,23 +32,6 @@ spec:
           ports:
             - name: http-server
               containerPort: {{ .Values.rcs.deployment.port }}
-          readinessProbe:
-            httpGet:
-              path: /dev/info
-              port: {{ .Values.rcs.deployment.port }}
-            periodSeconds: 5
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 5
-          livenessProbe:
-            httpGet:
-              path: /dev/info
-              port: {{ .Values.rcs.deployment.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 5
-            successThreshold: 1
-            timeoutSeconds: 5
           env:
             - name: DOMAIN
               value: {{ .Values.domain }}

--- a/_infra/helm/securebanking-ui/templates/swagger-deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/swagger-deployment.yaml
@@ -32,23 +32,6 @@ spec:
           ports:
             - name: http-server
               containerPort: {{ .Values.swagger.deployment.port }}
-          readinessProbe:
-            httpGet:
-              path: /dev/info
-              port: {{ .Values.swagger.deployment.port }}
-            periodSeconds: 5
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 5
-          livenessProbe:
-            httpGet:
-              path: /dev/info
-              port: {{ .Values.swagger.deployment.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 5
-            successThreshold: 1
-            timeoutSeconds: 5
           env:
             - name: DOMAIN
               value: {{ .Values.domain }}


### PR DESCRIPTION
Make a temporary change to the deployment manifests. Nginx is serving the node application and the current health checks are not being hit. The securebanking helm charts are derived from the openbanking charts and they have no health checks.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-ui/issues/17
issue: https://github.com/SecureBankingAccessToolkit/securebanking-ui/issues/13