### PR TITLE
rename subdomain to rcs-ui

### DIFF
--- a/_infra/helm/securebanking-ui/values.yaml
+++ b/_infra/helm/securebanking-ui/values.yaml
@@ -24,7 +24,7 @@ auth:
     resources: {}
 
 rcs:
-  subdomain: rcs
+  subdomain: rcs-ui
   deployment:
     port: 80
     replicas: 1


### PR DESCRIPTION
Rename the rcs ui subdomain to `rcs-ui`. The previous domain of `rcs` was conflicting with the api of the same name

issue: https://github.com/SecureBankingAccessToolkit/securebanking-ui/issues/13