### PR TITLE
Return selected account as OBAccount2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 .tern-port
 /securebanking-cli-ui/themes/
 .mongo
+.idea

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/components/account-selection/account-selection.component.html
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/components/account-selection/account-selection.component.html
@@ -18,7 +18,7 @@
 
               <span fxFlex></span>
               <div class="Aligner">
-                <mat-radio-button fxFlex class="Aligner-item" [value]="account.account.accounts[0]"></mat-radio-button>
+                <mat-radio-button fxFlex class="Aligner-item" [value]="account.account"></mat-radio-button>
               </div>
             </div>
           </div>

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank DomesticPaymentComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    }
+      "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+      "currency":"GBP",
+      "nickname":"UK Bills",
+      "accounts":[
+        {
+          "schemeName":"UK.OBIE.SortCodeAccountNumber",
+          "identification":"4938761144202",
+          "name":"c417136f-91e4-4abe-985e-f757496e5458",
+          "secondaryIdentification":"17508172"
+        }
+      ]
+    };
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank DomesticPaymentComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    }
+      "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+      "currency":"GBP",
+      "nickname":"UK Bills",
+      "accounts":[
+        {
+          "schemeName":"UK.OBIE.SortCodeAccountNumber",
+          "identification":"4938761144202",
+          "name":"c417136f-91e4-4abe-985e-f757496e5458",
+          "secondaryIdentification":"17508172"
+        }
+      ]
+    };
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    }
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    }
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank DomesticStandingOrderComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    }
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank DomesticStandingOrderComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    }
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank FilePaymentComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    }
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank FilePaymentComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank InternationalPaymentComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank InternationalPaymentComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank InternationalStandingOrderComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank InternationalStandingOrderComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.spec.ts
@@ -64,11 +64,18 @@ describe('app:bank SinglePaymentComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
@@ -83,11 +90,18 @@ describe('app:bank SinglePaymentComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "79126738233670",
-      name: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      secondaryIdentification: "49704112"
-    };
+   "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
+   "currency":"GBP",
+   "nickname":"UK Bills",
+   "accounts":[
+      {
+         "schemeName":"UK.OBIE.SortCodeAccountNumber",
+         "identification":"4938761144202",
+         "name":"c417136f-91e4-4abe-985e-f757496e5458",
+         "secondaryIdentification":"17508172"
+      }
+   ]
+};;
     spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/297

### Implementation
- Return the selected account from the domestic payment decision as OBAccount2
- Fix the unit tests