### PR TITLE
237: field sharedaccounts to accountIds, direct mapping on RCS

### DIFF
--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/account/account.component.spec.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/account/account.component.spec.ts
@@ -57,7 +57,7 @@ describe('app:rcs AccountComponent', () => {
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
-      sharedAccounts: []
+      accountIds: []
     });
   });
 
@@ -69,7 +69,7 @@ describe('app:rcs AccountComponent', () => {
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
-      sharedAccounts: []
+      accountIds: []
     });
   });
 
@@ -81,7 +81,7 @@ describe('app:rcs AccountComponent', () => {
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,
-      sharedAccounts: []
+      accountIds: []
     });
   });
 });

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/account/account.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/account/account.component.ts
@@ -85,7 +85,7 @@ export class AccountComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      sharedAccounts: Object.keys(this.form.value).filter(k => this.form.value[k])
+      accountIds: Object.keys(this.form.value).filter(k => this.form.value[k])
     });
   }
 }

--- a/securebanking-rcs-ui/projects/rcs/src/app/types/consentItem.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/types/consentItem.ts
@@ -21,6 +21,6 @@ export interface Item {
 
 export interface IConsentEventEmitter {
   decision: string;
-  sharedAccounts?: string[];
+  accountIds?: string[];
   debtorAccount?: OBCashAccount3;
 }


### PR DESCRIPTION
- Modified the interface `IConsentEventEmitter` to rename the field `sharedAccounts` to `accountIds` for direct mapping on RCS backend
IssueL https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/237