### PR TITLE
356: Date and Amount Fields in RCS-UI for the Final Payment are reversed

### DIFF
--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
@@ -94,8 +94,8 @@ export class DomesticStandingOrderComponent implements OnInit {
         type: ItemType.FINAL_PAYMENT,
         payload: {
           finalPaymentLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT',
-          finalPaymentDateLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_AMOUNT',
-          finalPaymentAmountLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_DATE',
+          finalPaymentDateLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_DATE',
+          finalPaymentAmountLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_AMOUNT',
           finalPaymentDate: this.response.standingOrder.finalPaymentDateTime,
           finalPaymentAmount: this.response.standingOrder.finalPaymentAmount,
           cssClass: 'domestic-standing-order-FinalPayment'

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
@@ -95,8 +95,8 @@ export class InternationalStandingOrderComponent implements OnInit {
         type: ItemType.FINAL_PAYMENT,
         payload: {
           finalPaymentLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT',
-          finalPaymentDateLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_AMOUNT',
-          finalPaymentAmountLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_DATE',
+          finalPaymentDateLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_DATE',
+          finalPaymentAmountLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_AMOUNT',
           finalPaymentDate: this.response.standingOrder.finalPaymentDateTime,
           finalPaymentAmount: this.response.standingOrder.finalPaymentAmount,
           cssClass: 'file-payment-FinalPayment'


### PR DESCRIPTION
https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/356