### PR TITLE
390: Updating ingress.yaml to apiVersion: networking.k8s.io/v1

### DIFF
--- a/_infra/helm/securebanking-ui/templates/ingress.yaml
+++ b/_infra/helm/securebanking-ui/templates/ingress.yaml
@@ -17,16 +17,22 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ .Chart.Name }}-{{ .Values.rcsUI.subdomain }}
-          servicePort: 8080
+          service:
+            name: {{ .Chart.Name }}-{{ .Values.rcsUI.subdomain }}
+            port:
+              number: 8080
         path: /
+        pathType: Prefix
   - host: {{ .Values.swaggerUI.subdomain }}.{{ .Values.ingress.domain }}
     http:
       paths:
       - backend:
-          serviceName: {{ .Chart.Name }}-{{ .Values.swaggerUI.subdomain }}
-          servicePort: 8080
+          service:
+            name: {{ .Chart.Name }}-{{ .Values.swaggerUI.subdomain }}
+            port:
+              number: 8080
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ .Values.ingress.tls.subdomain }}.{{ .Values.ingress.domain }}"

--- a/_infra/helm/securebanking-ui/values.yaml
+++ b/_infra/helm/securebanking-ui/values.yaml
@@ -55,7 +55,7 @@ swaggerUI:
     resources: {}
 
 ingress:
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   class: nginx
   additionalAnnotations:
     nginx.ingress.kubernetes.io/client-body-buffer-size: 1m


### PR DESCRIPTION
Updating ingress.yaml to apiVersion: networking.k8s.io/v1

This is required to be able to upgrade the cluster to k8s 1.22

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/390