### PR TITLE
486: update consent components to display calculated elements

### DIFF
--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
@@ -2,150 +2,154 @@ module.exports = {
   "type": "InternationalPaymentConsentDetails",
   "decisionApiUri": "/api/rcs/consent/decision/",
   "username": "psu4test",
-  "userId": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
+  "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
   "logo": "https://forgerock.com",
-  "clientId": "eb7e13d0-d7a8-449c-94c3-6d18aaed85e4",
+  "clientId": "ec0a5142-ea7c-4b82-8ff0-f24e3a526a9c",
   "instructedAmount": {
-      "amount": "10.01",
-      "currency": "GBP"
+    "amount": "10.01",
+    "currency": "GBP"
   },
   "exchangeRateInformation": {
-      "unitCurrency": "EUR",
-      "exchangeRate": "10",
-      "rateType": "AGREED",
-      "contractIdentification": "/tbill/2018/T102993"
+    "unitCurrency": "EUR",
+    "exchangeRate": 10,
+    "rateType": "AGREED",
+    "contractIdentification": "/tbill/2018/T102993"
+  },
+  "charges": {
+    "amount": "1.5",
+    "currency": "GBP"
   },
   "merchantName": "Automating-testing",
-  "currencyOfTransfer": "USD",
+  "currencyOfTransfer": "EUR",
   "paymentReference": "FRESCO-037",
   "accounts": [
-      {
-          "id": "afe693ce-6b45-4b2b-abaf-b42056a135c5",
-          "userId": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
-          "account": {
-              "accountId": "afe693ce-6b45-4b2b-abaf-b42056a135c5",
-              "status": "Enabled",
-              "statusUpdateDateTime": "2022-07-06T06:39:11.115Z",
-              "currency": "GBP",
-              "accountType": "Personal",
-              "accountSubType": "CurrentAccount",
-              "nickname": "UK Bills",
-              "openingDate": "2022-07-05T06:39:11.115Z",
-              "maturityDate": "2022-07-07T06:39:11.116Z",
-              "accounts": [
-                  {
-                      "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                      "identification": "51497750767868",
-                      "name": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
-                      "secondaryIdentification": "15878292"
-                  }
-              ],
-              "firstAccount": {
-                  "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                  "identification": "51497750767868",
-                  "name": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
-                  "secondaryIdentification": "15878292"
-              }
-          },
-          "latestStatementId": "7c4751ca-83ec-4928-870b-496d69ac2a8d",
-          "created": "2022-07-06T06:39:11.094Z",
-          "balances": [
-              {
-                  "accountId": "afe693ce-6b45-4b2b-abaf-b42056a135c5",
-                  "creditDebitIndicator": "Debit",
-                  "type": "InterimAvailable",
-                  "dateTime": "2022-07-06T06:39:11.389Z",
-                  "amount": {
-                      "amount": "9172.87",
-                      "currency": "GBP"
-                  }
-              }
-          ]
+    {
+      "id": "c2b6d4e4-8881-4d2b-afec-6f636479cf08",
+      "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+      "account": {
+        "accountId": "c2b6d4e4-8881-4d2b-afec-6f636479cf08",
+        "status": "Enabled",
+        "statusUpdateDateTime": "2022-08-17T06:12:12.000Z",
+        "currency": "GBP",
+        "accountType": "Personal",
+        "accountSubType": "CurrentAccount",
+        "nickname": "UK Bills",
+        "openingDate": "2022-08-16T06:12:12.000Z",
+        "maturityDate": "2022-08-18T06:12:12.000Z",
+        "accounts": [
+          {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "21676417575588",
+            "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+            "secondaryIdentification": "93361307"
+          }
+        ],
+        "firstAccount": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "21676417575588",
+          "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+          "secondaryIdentification": "93361307"
+        }
       },
-      {
-          "id": "b6a6ceb1-db4d-42d6-9e53-81c4887c931c",
-          "userId": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
-          "account": {
-              "accountId": "b6a6ceb1-db4d-42d6-9e53-81c4887c931c",
-              "status": "Enabled",
-              "statusUpdateDateTime": "2022-07-06T06:39:13.639Z",
-              "currency": "EUR",
-              "accountType": "Personal",
-              "accountSubType": "CurrentAccount",
-              "nickname": "FR Bills",
-              "openingDate": "2022-07-05T06:39:13.639Z",
-              "maturityDate": "2022-07-07T06:39:13.639Z",
-              "accounts": [
-                  {
-                      "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                      "identification": "19127546367088",
-                      "name": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
-                      "secondaryIdentification": "3437348"
-                  }
-              ],
-              "firstAccount": {
-                  "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                  "identification": "19127546367088",
-                  "name": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
-                  "secondaryIdentification": "3437348"
-              }
-          },
-          "latestStatementId": "a6815a32-bd5e-427e-9819-5f8cfdeaab90",
-          "created": "2022-07-06T06:39:13.639Z",
-          "balances": [
-              {
-                  "accountId": "b6a6ceb1-db4d-42d6-9e53-81c4887c931c",
-                  "creditDebitIndicator": "Debit",
-                  "type": "InterimAvailable",
-                  "dateTime": "2022-07-06T06:39:13.641Z",
-                  "amount": {
-                      "amount": "6320.67",
-                      "currency": "EUR"
-                  }
-              }
-          ]
+      "latestStatementId": "1f520a6f-5b9d-47c1-a821-bd51bb346493",
+      "created": "2022-08-17T06:12:12.000Z",
+      "balances": [
+        {
+          "accountId": "c2b6d4e4-8881-4d2b-afec-6f636479cf08",
+          "creditDebitIndicator": "Debit",
+          "type": "InterimAvailable",
+          "dateTime": "2022-08-17T06:12:12.000Z",
+          "amount": {
+            "amount": "15657.68",
+            "currency": "GBP"
+          }
+        }
+      ]
+    },
+    {
+      "id": "aebfd722-d203-4bd1-ac9a-0242783b35d3",
+      "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+      "account": {
+        "accountId": "aebfd722-d203-4bd1-ac9a-0242783b35d3",
+        "status": "Enabled",
+        "statusUpdateDateTime": "2022-08-17T06:12:15.000Z",
+        "currency": "EUR",
+        "accountType": "Personal",
+        "accountSubType": "CurrentAccount",
+        "nickname": "FR Bills",
+        "openingDate": "2022-08-16T06:12:15.000Z",
+        "maturityDate": "2022-08-18T06:12:15.000Z",
+        "accounts": [
+          {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "2647815018024",
+            "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+            "secondaryIdentification": "25240690"
+          }
+        ],
+        "firstAccount": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "2647815018024",
+          "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+          "secondaryIdentification": "25240690"
+        }
       },
-      {
-          "id": "4c4bdd91-bc2f-4390-9f54-060702413ce7",
-          "userId": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac",
-          "account": {
-              "accountId": "4c4bdd91-bc2f-4390-9f54-060702413ce7",
-              "status": "Enabled",
-              "statusUpdateDateTime": "2022-07-06T06:39:14.604Z",
-              "currency": "GBP",
-              "accountType": "Personal",
-              "accountSubType": "CurrentAccount",
-              "nickname": "Household",
-              "openingDate": "2022-07-05T06:39:14.604Z",
-              "maturityDate": "2022-07-07T06:39:14.604Z",
-              "accounts": [
-                  {
-                      "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                      "identification": "92389168525341",
-                      "name": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac"
-                  }
-              ],
-              "firstAccount": {
-                  "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                  "identification": "92389168525341",
-                  "name": "5ea4043f-76b4-4aff-873f-0086eb6cf6ac"
-              }
-          },
-          "latestStatementId": "34d33129-565f-4949-9c74-8934b9654133",
-          "created": "2022-07-06T06:39:14.604Z",
-          "balances": [
-              {
-                  "accountId": "4c4bdd91-bc2f-4390-9f54-060702413ce7",
-                  "creditDebitIndicator": "Debit",
-                  "type": "InterimAvailable",
-                  "dateTime": "2022-07-06T06:39:14.606Z",
-                  "amount": {
-                      "amount": "4963.87",
-                      "currency": "GBP"
-                  }
-              }
-          ]
-      }
+      "latestStatementId": "30f9d176-14c0-40e8-89ef-3114516004a8",
+      "created": "2022-08-17T06:12:15.000Z",
+      "balances": [
+        {
+          "accountId": "aebfd722-d203-4bd1-ac9a-0242783b35d3",
+          "creditDebitIndicator": "Debit",
+          "type": "InterimAvailable",
+          "dateTime": "2022-08-17T06:12:15.000Z",
+          "amount": {
+            "amount": "1234.68",
+            "currency": "EUR"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e24fa6fe-b4df-40dd-9fe7-aa07bc56db56",
+      "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+      "account": {
+        "accountId": "e24fa6fe-b4df-40dd-9fe7-aa07bc56db56",
+        "status": "Enabled",
+        "statusUpdateDateTime": "2022-08-17T06:12:16.000Z",
+        "currency": "GBP",
+        "accountType": "Personal",
+        "accountSubType": "CurrentAccount",
+        "nickname": "Household",
+        "openingDate": "2022-08-16T06:12:16.000Z",
+        "maturityDate": "2022-08-18T06:12:16.000Z",
+        "accounts": [
+          {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "5849097294991",
+            "name": "86228a9d-812d-4a15-a2f7-6a45488e593b"
+          }
+        ],
+        "firstAccount": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "5849097294991",
+          "name": "86228a9d-812d-4a15-a2f7-6a45488e593b"
+        }
+      },
+      "latestStatementId": "704e5532-a04f-4fa1-8cd4-cf52582e62bc",
+      "created": "2022-08-17T06:12:16.000Z",
+      "balances": [
+        {
+          "accountId": "e24fa6fe-b4df-40dd-9fe7-aa07bc56db56",
+          "creditDebitIndicator": "Debit",
+          "type": "InterimAvailable",
+          "dateTime": "2022-08-17T06:12:16.000Z",
+          "amount": {
+            "amount": "8561.19",
+            "currency": "GBP"
+          }
+        }
+      ]
+    }
   ],
   "intentType": "PAYMENT_INTERNATIONAL_CONSENT"
 }

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
@@ -1,152 +1,156 @@
 module.exports = {
-    "type": "InternationalScheduledPaymentConsentDetails",
-    "decisionApiUri": "/api/rcs/consent/decision/",
-    "username": "psu4test",
-    "userId": "8e465e16-e10d-4456-95ac-f558f135e81d",
-    "logo": "https://forgerock.com",
-    "clientId": "bd8ca1a6-f7cf-4220-8cea-cc7f9631de2c",
-    "instructedAmount": {
-        "amount": "10.01",
-        "currency": "GBP"
-    },
-    "exchangeRateInformation": {
-        "unitCurrency": "EUR",
-        "exchangeRate": 10,
-        "rateType": "AGREED",
-        "contractIdentification": "/tbill/2018/T102993"
-    },
-    "merchantName": "Automating-testing",
-    "paymentDate": "2022-07-21T08:46:53.000Z",
-    "currencyOfTransfer": "USD",
-    "paymentReference": "FRESCO-037",
-    "accounts": [
-        {
-            "id": "b50d7c30-2d0c-4191-994f-038494ed04fe",
-            "userId": "8e465e16-e10d-4456-95ac-f558f135e81d",
-            "account": {
-                "accountId": "b50d7c30-2d0c-4191-994f-038494ed04fe",
-                "status": "Enabled",
-                "statusUpdateDateTime": "2022-07-22T06:11:10.374Z",
-                "currency": "GBP",
-                "accountType": "Personal",
-                "accountSubType": "CurrentAccount",
-                "nickname": "UK Bills",
-                "openingDate": "2022-07-21T06:11:10.374Z",
-                "maturityDate": "2022-07-23T06:11:10.375Z",
-                "accounts": [
-                    {
-                        "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                        "identification": "70005730618981",
-                        "name": "8e465e16-e10d-4456-95ac-f558f135e81d",
-                        "secondaryIdentification": "10745775"
-                    }
-                ],
-                "firstAccount": {
-                    "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                    "identification": "70005730618981",
-                    "name": "8e465e16-e10d-4456-95ac-f558f135e81d",
-                    "secondaryIdentification": "10745775"
-                }
-            },
-            "latestStatementId": "514a5d58-b2dc-4b87-ba2f-d6d9e26b2f63",
-            "created": "2022-07-22T06:11:10.306Z",
-            "balances": [
-                {
-                    "accountId": "b50d7c30-2d0c-4191-994f-038494ed04fe",
-                    "creditDebitIndicator": "Debit",
-                    "type": "InterimAvailable",
-                    "dateTime": "2022-07-22T06:11:10.573Z",
-                    "amount": {
-                        "amount": "12229.04",
-                        "currency": "GBP"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "ff3ec24e-9a3e-46db-b2ca-22441314e3d5",
-            "userId": "8e465e16-e10d-4456-95ac-f558f135e81d",
-            "account": {
-                "accountId": "ff3ec24e-9a3e-46db-b2ca-22441314e3d5",
-                "status": "Enabled",
-                "statusUpdateDateTime": "2022-07-22T06:11:12.721Z",
-                "currency": "EUR",
-                "accountType": "Personal",
-                "accountSubType": "CurrentAccount",
-                "nickname": "FR Bills",
-                "openingDate": "2022-07-21T06:11:12.721Z",
-                "maturityDate": "2022-07-23T06:11:12.721Z",
-                "accounts": [
-                    {
-                        "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                        "identification": "72306585225098",
-                        "name": "8e465e16-e10d-4456-95ac-f558f135e81d",
-                        "secondaryIdentification": "90689405"
-                    }
-                ],
-                "firstAccount": {
-                    "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                    "identification": "72306585225098",
-                    "name": "8e465e16-e10d-4456-95ac-f558f135e81d",
-                    "secondaryIdentification": "90689405"
-                }
-            },
-            "latestStatementId": "9affaafd-e90d-4c26-adbd-b0a8319fb462",
-            "created": "2022-07-22T06:11:12.721Z",
-            "balances": [
-                {
-                    "accountId": "ff3ec24e-9a3e-46db-b2ca-22441314e3d5",
-                    "creditDebitIndicator": "Debit",
-                    "type": "InterimAvailable",
-                    "dateTime": "2022-07-22T06:11:12.724Z",
-                    "amount": {
-                        "amount": "16903.80",
-                        "currency": "EUR"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "b0dd584f-5d07-46cd-9c2d-f989ed0c79df",
-            "userId": "8e465e16-e10d-4456-95ac-f558f135e81d",
-            "account": {
-                "accountId": "b0dd584f-5d07-46cd-9c2d-f989ed0c79df",
-                "status": "Enabled",
-                "statusUpdateDateTime": "2022-07-22T06:11:13.517Z",
-                "currency": "GBP",
-                "accountType": "Personal",
-                "accountSubType": "CurrentAccount",
-                "nickname": "Household",
-                "openingDate": "2022-07-21T06:11:13.517Z",
-                "maturityDate": "2022-07-23T06:11:13.517Z",
-                "accounts": [
-                    {
-                        "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                        "identification": "78577781690632",
-                        "name": "8e465e16-e10d-4456-95ac-f558f135e81d"
-                    }
-                ],
-                "firstAccount": {
-                    "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                    "identification": "78577781690632",
-                    "name": "8e465e16-e10d-4456-95ac-f558f135e81d"
-                }
-            },
-            "latestStatementId": "ad27071b-edc3-4f54-a3ee-586ddd71ba2c",
-            "created": "2022-07-22T06:11:13.517Z",
-            "balances": [
-                {
-                    "accountId": "b0dd584f-5d07-46cd-9c2d-f989ed0c79df",
-                    "creditDebitIndicator": "Debit",
-                    "type": "InterimAvailable",
-                    "dateTime": "2022-07-22T06:11:13.519Z",
-                    "amount": {
-                        "amount": "4803.13",
-                        "currency": "GBP"
-                    }
-                }
-            ]
+  "type": "InternationalScheduledPaymentConsentDetails",
+  "decisionApiUri": "/api/rcs/consent/decision/",
+  "username": "psu4test",
+  "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+  "logo": "https://forgerock.com",
+  "clientId": "ec0a5142-ea7c-4b82-8ff0-f24e3a526a9c",
+  "instructedAmount": {
+    "amount": "10.01",
+    "currency": "GBP"
+  },
+  "charges": {
+    "amount": "1.5",
+    "currency": "GBP"
+  },
+  "exchangeRateInformation": {
+    "unitCurrency": "EUR",
+    "exchangeRate": 10,
+    "rateType": "AGREED",
+    "contractIdentification": "/tbill/2018/T102993"
+  },
+  "merchantName": "Automating-testing",
+  "paymentDate": "2022-09-21T08:46:53.000Z",
+  "currencyOfTransfer": "EUR",
+  "paymentReference": "FRESCO-037",
+  "accounts": [
+    {
+      "id": "c2b6d4e4-8881-4d2b-afec-6f636479cf08",
+      "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+      "account": {
+        "accountId": "c2b6d4e4-8881-4d2b-afec-6f636479cf08",
+        "status": "Enabled",
+        "statusUpdateDateTime": "2022-08-17T06:12:12.000Z",
+        "currency": "GBP",
+        "accountType": "Personal",
+        "accountSubType": "CurrentAccount",
+        "nickname": "UK Bills",
+        "openingDate": "2022-08-16T06:12:12.000Z",
+        "maturityDate": "2022-08-18T06:12:12.000Z",
+        "accounts": [
+          {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "21676417575588",
+            "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+            "secondaryIdentification": "93361307"
+          }
+        ],
+        "firstAccount": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "21676417575588",
+          "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+          "secondaryIdentification": "93361307"
         }
-    ],
-    "intentType": "PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT"
+      },
+      "latestStatementId": "1f520a6f-5b9d-47c1-a821-bd51bb346493",
+      "created": "2022-08-17T06:12:12.000Z",
+      "balances": [
+        {
+          "accountId": "c2b6d4e4-8881-4d2b-afec-6f636479cf08",
+          "creditDebitIndicator": "Debit",
+          "type": "InterimAvailable",
+          "dateTime": "2022-08-17T06:12:12.000Z",
+          "amount": {
+            "amount": "15657.68",
+            "currency": "GBP"
+          }
+        }
+      ]
+    },
+    {
+      "id": "aebfd722-d203-4bd1-ac9a-0242783b35d3",
+      "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+      "account": {
+        "accountId": "aebfd722-d203-4bd1-ac9a-0242783b35d3",
+        "status": "Enabled",
+        "statusUpdateDateTime": "2022-08-17T06:12:15.000Z",
+        "currency": "EUR",
+        "accountType": "Personal",
+        "accountSubType": "CurrentAccount",
+        "nickname": "FR Bills",
+        "openingDate": "2022-08-16T06:12:15.000Z",
+        "maturityDate": "2022-08-18T06:12:15.000Z",
+        "accounts": [
+          {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "2647815018024",
+            "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+            "secondaryIdentification": "25240690"
+          }
+        ],
+        "firstAccount": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "2647815018024",
+          "name": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+          "secondaryIdentification": "25240690"
+        }
+      },
+      "latestStatementId": "30f9d176-14c0-40e8-89ef-3114516004a8",
+      "created": "2022-08-17T06:12:15.000Z",
+      "balances": [
+        {
+          "accountId": "aebfd722-d203-4bd1-ac9a-0242783b35d3",
+          "creditDebitIndicator": "Debit",
+          "type": "InterimAvailable",
+          "dateTime": "2022-08-17T06:12:15.000Z",
+          "amount": {
+            "amount": "1234.68",
+            "currency": "EUR"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e24fa6fe-b4df-40dd-9fe7-aa07bc56db56",
+      "userId": "86228a9d-812d-4a15-a2f7-6a45488e593b",
+      "account": {
+        "accountId": "e24fa6fe-b4df-40dd-9fe7-aa07bc56db56",
+        "status": "Enabled",
+        "statusUpdateDateTime": "2022-08-17T06:12:16.000Z",
+        "currency": "GBP",
+        "accountType": "Personal",
+        "accountSubType": "CurrentAccount",
+        "nickname": "Household",
+        "openingDate": "2022-08-16T06:12:16.000Z",
+        "maturityDate": "2022-08-18T06:12:16.000Z",
+        "accounts": [
+          {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "5849097294991",
+            "name": "86228a9d-812d-4a15-a2f7-6a45488e593b"
+          }
+        ],
+        "firstAccount": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "5849097294991",
+          "name": "86228a9d-812d-4a15-a2f7-6a45488e593b"
+        }
+      },
+      "latestStatementId": "704e5532-a04f-4fa1-8cd4-cf52582e62bc",
+      "created": "2022-08-17T06:12:16.000Z",
+      "balances": [
+        {
+          "accountId": "e24fa6fe-b4df-40dd-9fe7-aa07bc56db56",
+          "creditDebitIndicator": "Debit",
+          "type": "InterimAvailable",
+          "dateTime": "2022-08-17T06:12:16.000Z",
+          "amount": {
+            "amount": "8561.19",
+            "currency": "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  "intentType": "PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT"
 }

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
@@ -114,13 +114,22 @@ export class InternationalPaymentComponent implements OnInit {
       }
     });
 
-    if (_get(this.response, 'exchangeRateInformation.unitCurrency')) {
+    if (_get(this.response, 'charges.amount')) {
+      this.rateItems.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.CHARGES',
+          value: this.response.charges.amount + ' ' + this.response.charges.currency,
+          cssClass: 'international-payment-charges'
+        }
+      });
+    } else {
       this.rateItems.push({
         type: ItemType.STRING,
         payload: {
           label: 'CONSENT.PAYMENT.CHARGES',
           value: '0.0 ' + this.response.exchangeRateInformation.unitCurrency,
-          cssClass: 'international-payment-unit-currency'
+          cssClass: 'international-payment-charges'
         }
       });
     }

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
@@ -123,7 +123,7 @@ export class InternationalPaymentComponent implements OnInit {
           cssClass: 'international-payment-charges'
         }
       });
-    } else {
+    } else if(_get(this.response, 'exchangeRateInformation.unitCurrency')){
       this.rateItems.push({
         type: ItemType.STRING,
         payload: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
@@ -124,13 +124,22 @@ export class InternationalSchedulePaymentComponent implements OnInit {
         }
       });
     }
-    if (_get(this.response, 'exchangeRateInformation.unitCurrency')) {
+    if (_get(this.response, 'charges.amount')) {
+      this.rateItems.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.CHARGES',
+          value: this.response.charges.amount + ' ' + this.response.charges.currency,
+          cssClass: 'international-scheduled-payment-charges'
+        }
+      });
+    } else {
       this.rateItems.push({
         type: ItemType.STRING,
         payload: {
           label: 'CONSENT.PAYMENT.CHARGES',
           value: '0.0 ' + this.response.exchangeRateInformation.unitCurrency,
-          cssClass: 'international-schedule-payment-unit-currency'
+          cssClass: 'international-scheduled-payment-charges'
         }
       });
     }

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
@@ -133,7 +133,7 @@ export class InternationalSchedulePaymentComponent implements OnInit {
           cssClass: 'international-scheduled-payment-charges'
         }
       });
-    } else {
+    } else if(_get(this.response, 'exchangeRateInformation.unitCurrency')){
       this.rateItems.push({
         type: ItemType.STRING,
         payload: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/types/api.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/types/api.ts
@@ -47,6 +47,7 @@ export module ApiResponses {
     paymentDate?: string; // domestic scheduled payment
     instructedAmount?: OBActiveOrHistoricCurrencyAndAmount;
     exchangeRateInformation?: Rate;
+    charges?: Charges;
     numberOfTransactions?: string;
     totalAmount?: string;
     paymentReference?: string;
@@ -93,6 +94,11 @@ export class ControlParameters {
 export class PeriodicLimits {
   periodType?: string;
   periodAlignment?: string;
+  amount?: number;
+  currency?: string;
+}
+
+export class Charges {
   amount?: number;
   currency?: string;
 }


### PR DESCRIPTION
- Updated international payment consent details component
- Updated international scheduled payment consent details components
- Updated api classes to add the charges property and to be mapping from the rs consent details response
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/486