### PR TITLE
552: file payment consent details display

### DIFF
--- a/securebanking-rcs-ui/README.md
+++ b/securebanking-rcs-ui/README.md
@@ -22,6 +22,17 @@ npm run serve.rcs.local
 | `/dev/consent` | consent mock list view      | src/app/pages/consent-dev | Mock files: src/app/pages/consent-dev/mocks |
 | `/dev/info`    | application properties view | It is a app route         | N/A                                         |
 
+## Test RCS ui app
+This task must be mandatory before push any change to avoid get failures from git actions.
+```shell
+npm ci # (only if necessary)
+```
+```shell
+npm run lint
+```
+```shell
+npm run test
+```
 ## RCS Docker image
 ### Build
 ```bash

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/consent-dev.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/consent-dev.component.ts
@@ -8,6 +8,7 @@ import mock5 from './mocks/domestic-standing-order-response-details';
 import mock6 from './mocks/international-payment-consent-details';
 import mock7 from './mocks/international-scheduled-payment-consent-details';
 import mock8 from './mocks/international-standing-order-consent-details';
+import mock9 from './mocks/file-payment-consent-details';
 
 import { IConsentEventEmitter } from '../../types/consentItem';
 
@@ -19,14 +20,13 @@ import { IConsentEventEmitter } from '../../types/consentItem';
 })
 export class ConsentDevComponent implements OnInit {
   loading = false;
-  mocks: any[] = [mock1, mock2, mock3, mock4, mock5, mock6, mock7, mock8];
-
+  mocks: any[] = [mock1, mock2, mock3, mock4, mock5, mock6, mock7, mock8, mock9];
   constructor(private cdr: ChangeDetectorRef) {}
 
   ngOnInit() {}
 
   onFormSubmit(values: IConsentEventEmitter) {
-    console.log(`Submitted values: ${values}`)
+    console.log(`Submitted values: ${JSON.stringify(values)}`)
     this.loading = true;
     setTimeout(() => {
       this.loading = false;

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/file-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/file-payment-consent-details.js
@@ -1,0 +1,64 @@
+module.exports = {
+  "type": "FilePaymentConsentDetails",
+  "decisionApiUri": "/api/rcs/consent/decision/",
+  "username": "testUserName",
+  "userId": "c7303aee-2ff1-44b5-b21f-a7a3aaf39271",
+  "logo": "https://www.vhv.rs/dpng/d/455-4556963_warner-bros-logo-warner-brothers-logo-png-transparent.png",
+  "clientId": "3bce98ec-755f-42f6-9f82-0a120a6db559",
+  "filePayment": {
+    "fileReference": "XmlExample",
+    "numberOfTransactions": "3",
+    "controlSum": 11500000,
+    "requestedExecutionDateTime": "2023-09-27T13:03:06.000Z"
+  },
+  "accounts": [
+    {
+      "id": "123456",
+      "account": {
+        "accountId": "1234",
+        "status": "Enabled",
+        "statusUpdateDateTime": "2022-10-21T17:20:40.047Z",
+        "currency": "GBP",
+        "accountType": "Personal",
+        "accountSubType": "CurrentAccount",
+        "description": "A personal current account",
+        "nickname": "House Account",
+        "openingDate": "2022-10-20T17:20:40.047Z",
+        "accounts": [
+          {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "40400411290112",
+            "name": "Mr A Jones"
+          }
+        ],
+        "servicer": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "9876"
+        },
+        "firstAccount": {
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "40400411290112",
+          "name": "Mr A Jones"
+        }
+      },
+      "balances": [
+        {
+          "accountId": "12345",
+          "creditDebitIndicator": "Credit",
+          "type": "InterimAvailable",
+          "dateTime": "2022-10-21T17:20:40.048Z",
+          "amount": {
+            "amount": "10.00",
+            "currency": "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  "charges": {
+    "amount": "21.11",
+    "currency": "GBP"
+  },
+  "merchantName": "PISP Name",
+  "intentType": "PAYMENT_FILE_CONSENT"
+};

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.ts
@@ -52,7 +52,7 @@ export class FilePaymentComponent implements OnInit {
       type: ItemType.STRING,
       payload: {
         label: 'CONSENT.PAYMENT.PAYMENT_REFERENCE',
-        value: this.response.paymentReference,
+        value: this.response.filePayment.fileReference,
         cssClass: 'file-payment-paymentReference'
       }
     });
@@ -60,7 +60,7 @@ export class FilePaymentComponent implements OnInit {
       type: ItemType.STRING,
       payload: {
         label: 'CONSENT.FILE-PAYMENT.NO_OF_PAYEES',
-        value: this.response.numberOfTransactions,
+        value: this.response.filePayment.numberOfTransactions,
         cssClass: 'file-payment-numberOfTransactions'
       }
     });
@@ -68,7 +68,10 @@ export class FilePaymentComponent implements OnInit {
       type: ItemType.INSTRUCTED_AMOUNT,
       payload: {
         label: 'CONSENT.FILE-PAYMENT.TOTAL_AMOUNT',
-        amount: this.response.totalAmount,
+        amount: {
+          amount: this.response.filePayment.controlSum,
+          currency: "GBP"
+        },
         cssClass: 'file-payment-totalAmount'
       }
     });
@@ -76,7 +79,7 @@ export class FilePaymentComponent implements OnInit {
       type: ItemType.DATE,
       payload: {
         label: 'CONSENT.FILE-PAYMENT.PAYMENT_DATE',
-        date: this.response.requestedExecutionDateTime,
+        date: this.response.filePayment.requestedExecutionDateTime,
         cssClass: 'file-payment-requestedExecutionDateTime'
       }
     });

--- a/securebanking-rcs-ui/projects/rcs/src/app/types/api.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/types/api.ts
@@ -50,15 +50,17 @@ export module ApiResponses {
       instructedAmount: OBActiveOrHistoricCurrencyAndAmount;
       finalPaymentDateTime: string;
     };
+    filePayment?: {
+      fileReference: string;
+      numberOfTransactions: string;
+      controlSum: number;
+      requestedExecutionDateTime: string;
+    }
     paymentDate?: string; // domestic scheduled payment
     instructedAmount?: OBActiveOrHistoricCurrencyAndAmount;
     exchangeRateInformation?: Rate;
     charges?: Charges;
-    numberOfTransactions?: string;
-    totalAmount?: string;
     paymentReference?: string;
-    fileReference?: string;
-    requestedExecutionDateTime?: string;
     currencyOfTransfer?: string;
     expirationDateTime?: string;
     // special ui treatment


### PR DESCRIPTION
- Added mock for file payment consent component
- Delete unused file payment component fields from ApiResponses.ConsentDetailsResponse object
- Added instructions in rcs-ui README file to run the tests and validations before push changes
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/552