### PR TITLE
1702: Pick up correct RS_FQDN from config map

### DIFF
--- a/_infra/helm/securebanking-ui/templates/deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/deployment.yaml
@@ -47,6 +47,6 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: rs-sapig-deployment-config
-                  key: AS_FQDN
+                  key: RS_FQDN
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}


### PR DESCRIPTION
The RCS was using the AS_FQDN to call the RCS back end on, which is incorrect.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1702