### PR TITLE
Remove deprecated ComponentFactoryResolver ahead of Angular 17

### DIFF
--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/directives/dynamic-field.directive.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/directives/dynamic-field.directive.ts
@@ -1,5 +1,4 @@
 import {
-  ComponentFactoryResolver,
   ComponentRef,
   Directive,
   Input,
@@ -47,7 +46,7 @@ export class DynamicFieldDirective implements Field, OnChanges, OnInit {
 
   component: ComponentRef<Field>;
 
-  constructor(private resolver: ComponentFactoryResolver, private container: ViewContainerRef) {}
+  constructor(private container: ViewContainerRef) {}
 
   ngOnChanges() {
     if (this.component) {
@@ -65,8 +64,7 @@ export class DynamicFieldDirective implements Field, OnChanges, OnInit {
         Supported types: ${supportedTypes}`
       );
     } else {
-      const component = this.resolver.resolveComponentFactory<Field>(components[this.config.type]);
-      this.component = this.container.createComponent(component);
+      this.component = this.container.createComponent<Field>(components[this.config.type]);
       this.component.instance.authId = this.authId;
       this.component.instance.config = this.config;
       this.component.instance.group = this.group;

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/stages.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/stages.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ComponentFactoryResolver,
   EventEmitter,
   Input,
   OnChanges,
@@ -36,7 +35,7 @@ const log = debug('ForgerockAuthLogin:StagesComponent');
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class StagesComponent implements OnChanges {
-  constructor(protected route: ActivatedRoute, private componentFactoryResolver: ComponentFactoryResolver) {}
+  constructor(protected route: ActivatedRoute) {}
 
   @Input() response: ApiReponses.AuthLoginResponse;
   @Input() client: IConfigClient;
@@ -100,9 +99,8 @@ export class StagesComponent implements OnChanges {
 
   private loadComponent(componentInstance) {
     // Select, clear and inject the dynamic component with props data
-    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(componentInstance);
     this.dynamicTarget.clear();
-    const componentRef = this.dynamicTarget.createComponent(componentFactory);
+    const componentRef = this.dynamicTarget.createComponent(componentInstance);
     (<any>componentRef.instance).response = this.response;
     (<any>componentRef.instance).client = this.client;
     (<any>componentRef.instance).formSubmit = this.formSubmit;

--- a/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/customization.module.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/customization.module.ts
@@ -77,7 +77,7 @@ export function getCustomReducers() {
   ]
 })
 export class ForgerockCustomizationModule {
-  static forRoot(config: ForgerockCustomizationFactory): ModuleWithProviders<any> {
+  static forRoot(config: ForgerockCustomizationFactory): ModuleWithProviders<ForgerockCustomizationModule> {
     return {
       ngModule: ForgerockCustomizationModule,
       providers: [

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/toolbar/toolbar.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/toolbar/toolbar.component.ts
@@ -6,8 +6,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ComponentRef,
-  Inject,
-  ComponentFactoryResolver
+  Inject
 } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
 
@@ -36,7 +35,6 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   constructor(
     private _fuseSidebarService: ForgerockLayoutSidebarService,
     private configService: ForgerockConfigService,
-    private componentFactoryResolver: ComponentFactoryResolver,
     @Inject(ForgerockMainLayoutComponentsToken)
     private _components: IForgerockMainLayoutComponents
   ) {
@@ -49,9 +47,8 @@ export class ToolbarComponent implements OnInit, OnDestroy {
    */
   ngOnInit(): void {
     if (!this._components.toolbar) return;
-    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(this._components.toolbar);
     this.dynamicTarget.clear();
-    this.componentRef = this.dynamicTarget.createComponent(componentFactory);
+    this.componentRef = this.dynamicTarget.createComponent(this._components.toolbar);
   }
 
   /**

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/components/consent-box/items/dynamic-item/dynamic-item.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/components/consent-box/items/dynamic-item/dynamic-item.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ComponentFactoryResolver,
   Input,
   OnChanges,
   ViewChild,
@@ -36,7 +35,7 @@ import {
 export class DynamicItemComponent implements OnChanges {
   @Input() item: Item;
 
-  constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
+  constructor() {}
 
   @ViewChild('dynamicTarget', { read: ViewContainerRef, static: true })
   dynamicTarget: ViewContainerRef;
@@ -102,9 +101,8 @@ export class DynamicItemComponent implements OnChanges {
   }
 
   createComponent(componentInstance) {
-    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(componentInstance);
     this.dynamicTarget.clear();
-    const componentRef = this.dynamicTarget.createComponent(componentFactory);
+    const componentRef = this.dynamicTarget.createComponent(componentInstance);
     return <any>componentRef.instance;
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/dynamic/dynamic.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/dynamic/dynamic.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ComponentFactoryResolver,
   ComponentRef,
   EventEmitter,
   Input,
@@ -42,7 +41,7 @@ const log = debug('consent:DynamicComponent');
   encapsulation: ViewEncapsulation.None
 })
 export class DynamicComponent implements OnChanges {
-  constructor(private componentFactoryResolver: ComponentFactoryResolver) {
+  constructor() {
   }
 
   // @Input() decisionResponse: ApiResponses.ConsentDecisionResponse;
@@ -123,9 +122,8 @@ export class DynamicComponent implements OnChanges {
 
   createComponent(componentInstance: any) {
     // Select, clear and inject the dynamic component with props data
-    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(componentInstance);
     this.dynamicTarget.clear();
-    this.componentRef = this.dynamicTarget.createComponent(componentFactory);
+    this.componentRef = this.dynamicTarget.createComponent(componentInstance);
     this.componentRef.instance.response = this.response;
     this.componentRef.instance.loading = this.loading;
     this.componentRef.instance.formSubmit = this.formSubmit;


### PR DESCRIPTION
## Summary

- Replace all 5 usages of deprecated `ComponentFactoryResolver.resolveComponentFactory()` with the direct `ViewContainerRef.createComponent(ComponentClass)` API (introduced in Angular 13, `ComponentFactoryResolver` removed in Angular 17)
- Tighten `ModuleWithProviders<any>` to `ModuleWithProviders<ForgerockCustomizationModule>` in the customization module

## Files changed

**common:**
- `toolbar.component.ts` — dynamic toolbar injection
- `dynamic-field.directive.ts` — authentication dynamic form fields
- `stages.component.ts` — authentication stage loader

**rcs:**
- `dynamic.component.ts` — consent type router
- `dynamic-item.component.ts` — consent item type router

## Test plan

- [x] `npm run build` in `common` — 0 errors
- [x] `npm run test` in `common` — 69/69 passed
- [x] `npm run test` in `rcs` — 49/49 passed