### PR TITLE
chore: maintainability phase 2 — test runner and spy API migration

### DIFF
--- a/secure-api-gateway-ob-uk-ui-common/jest.config.js
+++ b/secure-api-gateway-ob-uk-ui-common/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   preset: 'jest-preset-angular',
   testPathIgnorePatterns: ['/node_modules/', '/src/test\\.ts$'],
-  testRunner: 'jest-jasmine2',
   transform: {
     '^.+\\.(ts|js|mjs|html|svg)$': ['jest-preset-angular', {
       stringifyContentPathRegex: '\\.(html|svg)$',

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/forgerock-auth-login.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/forgerock-auth-login.component.spec.ts
@@ -4,7 +4,7 @@ import { CookieModule } from 'ngx-cookie';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 
 import { LoginDynamicStagesModule } from './stages/stages.module';
@@ -23,7 +23,6 @@ describe('app:forgerock ForgerockAuthLoginComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ForgerockAuthLoginComponent],
       imports: [
-        RouterTestingModule.withRoutes([]),
         StoreModule.forRoot({}),
         CommonModule,
         TranslateModule.forRoot({}),
@@ -35,7 +34,8 @@ describe('app:forgerock ForgerockAuthLoginComponent', () => {
         ForgerockAuthApiModule,
         ForgerockConfigModule,
         ForgerockCustomerLogoModule
-      ]
+      ],
+      providers: [provideRouter([])]
     }).compileComponents();
   }));
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-oauth2-authorize/forgerock-auth-oauth2-authorize.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-oauth2-authorize/forgerock-auth-oauth2-authorize.component.spec.ts
@@ -4,7 +4,7 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { MatCardModule } from '@angular/material/card';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -30,7 +30,6 @@ describe('app:forgerock ForgerockAuthOauth2AuthorizeComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ForgerockAuthOauth2AuthorizeComponent],
       imports: [
-        RouterTestingModule.withRoutes([]),
         StoreModule.forRoot({}),
         CommonModule,
         TranslateModule.forRoot({}),
@@ -44,7 +43,7 @@ describe('app:forgerock ForgerockAuthOauth2AuthorizeComponent', () => {
         ForgerockCustomerLogoModule,
         ForgerockAlertModule
       ],
-      providers: [ForgerockConfigService]
+      providers: [provideRouter([]), ForgerockConfigService]
     }).compileComponents();
   }));
 
@@ -66,7 +65,7 @@ describe('app:forgerock ForgerockAuthOauth2AuthorizeComponent', () => {
       )}%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%2520id_token%26client_id%3Db61ab83a-a6f1-44c3-90c3-b514c93a9421%26state%3D10d260bf-a7d9-444a-92d9-7b7a5f088208%26redirect_uri%3Dhttps%253A%252F%252Fwww.google.com%26nonce%3D10d260bf-a7d9-444a-92d9-7b7a5f088208%26scope%3Dopenid%2520accounts%26request%3DeyJraWQiOi`
     );
 
-    spyOn(forgerockConfigService, 'get').and.returnValue(authorizationServer);
+    jest.spyOn(forgerockConfigService, 'get').mockReturnValue(authorizationServer);
     const newURL = component.updateRedirectionGotoIfAuthorizationServer(toTest);
     expect(newURL.toString()).toEqual(
       `https://bank.ui-integ.forgerock.financial/login?goto=${encodeURIComponent(
@@ -82,7 +81,7 @@ describe('app:forgerock ForgerockAuthOauth2AuthorizeComponent', () => {
       )}%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%2520id_token%26client_id%3Db61ab83a-a6f1-44c3-90c3-b514c93a9421%26state%3D10d260bf-a7d9-444a-92d9-7b7a5f088208%26redirect_uri%3Dhttps%253A%252F%252Fwww.google.com%26nonce%3D10d260bf-a7d9-444a-92d9-7b7a5f088208%26scope%3Dopenid%2520accounts%26request%3DeyJraWQiOi`
     );
 
-    spyOn(forgerockConfigService, 'get').and.returnValue(authorizationServer);
+    jest.spyOn(forgerockConfigService, 'get').mockReturnValue(authorizationServer);
     const newURL = component.updateRedirectionGotoIfAuthorizationServer(toTest);
     expect(newURL.toString()).toEqual(toTest.toString());
   });
@@ -94,7 +93,7 @@ describe('app:forgerock ForgerockAuthOauth2AuthorizeComponent', () => {
       )}%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%2520id_token%26client_id%3Db61ab83a-a6f1-44c3-90c3-b514c93a9421%26state%3D10d260bf-a7d9-444a-92d9-7b7a5f088208%26redirect_uri%3Dhttps%253A%252F%252Fwww.google.com%26nonce%3D10d260bf-a7d9-444a-92d9-7b7a5f088208%26scope%3Dopenid%2520accounts%26request%3DeyJraWQiOi`
     );
 
-    spyOn(forgerockConfigService, 'get').and.returnValue(authorizationServer);
+    jest.spyOn(forgerockConfigService, 'get').mockReturnValue(authorizationServer);
     const newURL = component.updateRedirectionGotoIfAuthorizationServer(toTest);
     expect(newURL.toString()).toEqual(toTest.toString());
   });

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-password/forgerock-auth-password.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-password/forgerock-auth-password.component.spec.ts
@@ -1,7 +1,7 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FlexLayoutModule } from '@angular/flex-layout';
@@ -24,7 +24,6 @@ describe('app:forgerock ForgerockAuthPasswordComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ForgerockAuthPasswordComponent],
       imports: [
-        RouterTestingModule.withRoutes([]),
         StoreModule.forRoot({}),
         CommonModule,
         TranslateModule.forRoot({}),
@@ -38,7 +37,8 @@ describe('app:forgerock ForgerockAuthPasswordComponent', () => {
         MatInputModule,
         MatProgressBarModule,
         ForgerockAuthProfileModule
-      ]
+      ],
+      providers: [provideRouter([])]
     }).compileComponents();
   }));
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-profile/forgerock-auth-profile.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-profile/forgerock-auth-profile.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { StoreModule } from '@ngrx/store';
@@ -17,7 +17,6 @@ describe('app:forgerock ProfileComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([]),
         StoreModule.forRoot({}),
         CommonModule,
         TranslateModule.forRoot({}),
@@ -25,7 +24,8 @@ describe('app:forgerock ProfileComponent', () => {
         MatTabsModule,
         ForgerockCustomerLogoModule
       ],
-      declarations: [ProfileComponent, ProfileContainerComponent]
+      declarations: [ProfileComponent, ProfileContainerComponent],
+      providers: [provideRouter([])]
     }).compileComponents();
   }));
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-register/forgerock-auth-register.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-register/forgerock-auth-register.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
@@ -28,7 +28,6 @@ describe('app:forgerock ForgerockAuthRegisterComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ForgerockAuthRegisterComponent],
       imports: [
-        RouterTestingModule.withRoutes([]),
         StoreModule.forRoot({}),
         TranslateModule.forRoot({}),
         NoopAnimationsModule,
@@ -45,7 +44,8 @@ describe('app:forgerock ForgerockAuthRegisterComponent', () => {
         MatCheckboxModule,
         ForgerockCustomerLogoModule,
         ForgerockMessagesModule
-      ]
+      ],
+      providers: [provideRouter([])]
     }).compileComponents();
   }));
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/guards/src/lib/can-customer-load.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/guards/src/lib/can-customer-load.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, provideRouter } from '@angular/router';
 
 import { ForgerockCustomerCanAccessGuard } from './can-customer-load';
 import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/services/forgerock-config';
@@ -12,8 +11,8 @@ describe('ForgerockCustomerCanAccessGuard', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([]), HttpClientTestingModule],
-      providers: [ForgerockCustomerCanAccessGuard, ForgerockConfigService]
+      imports: [HttpClientTestingModule],
+      providers: [provideRouter([]), ForgerockCustomerCanAccessGuard, ForgerockConfigService]
     });
     guard = TestBed.inject(ForgerockCustomerCanAccessGuard);
     router = TestBed.inject(Router);
@@ -27,7 +26,7 @@ describe('ForgerockCustomerCanAccessGuard', () => {
 
     it('should return false and navigate to /404 when URL is blacklisted', () => {
       guard.blacklist = ['blocked-route'];
-      const navigateSpy = spyOn(router, 'navigate');
+      const navigateSpy = jest.spyOn(router, 'navigate');
       expect(guard.isAccessGranted('blocked-route')).toBe(false);
       expect(navigateSpy).toHaveBeenCalledWith(['/404']);
     });
@@ -47,7 +46,7 @@ describe('ForgerockCustomerCanAccessGuard', () => {
 
     it('should deny access when route path is blacklisted', () => {
       guard.blacklist = ['forbidden'];
-      spyOn(router, 'navigate');
+      jest.spyOn(router, 'navigate');
       const result = guard.canLoad({ path: 'forbidden' });
       expect(result).toBe(false);
     });
@@ -63,7 +62,7 @@ describe('ForgerockCustomerCanAccessGuard', () => {
 
     it('should deny access when URL is blacklisted', () => {
       guard.blacklist = ['forbidden'];
-      spyOn(router, 'navigate');
+      jest.spyOn(router, 'navigate');
       const routeSnapshot: any = {};
       const stateSnapshot: any = { url: '/forbidden' };
       expect(guard.canActivate(routeSnapshot, stateSnapshot)).toBe(false);

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/pdf/src/pdf.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/pdf/src/pdf.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 import { PDFLayoutComponent } from './pdf.component';
 
@@ -10,7 +10,7 @@ describe('app:forgerock PDFLayoutComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [PDFLayoutComponent],
-      imports: [RouterTestingModule.withRoutes([])]
+      providers: [provideRouter([])]
     }).compileComponents();
   }));
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/simple/src/simple.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/simple/src/simple.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 import { SimpleLayoutComponent } from './simple.component';
 
@@ -10,7 +10,7 @@ describe('app:forgerock SimpleLayoutComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SimpleLayoutComponent],
-      imports: [RouterTestingModule.withRoutes([])]
+      providers: [provideRouter([])]
     }).compileComponents();
   }));
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/oidc/src/lib/store/effects/logout.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/oidc/src/lib/store/effects/logout.spec.ts
@@ -6,12 +6,17 @@ import { throwError } from 'rxjs';
 import { of } from 'rxjs';
 
 import { OIDCLogoutEffects } from './logout';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CommonModule } from '@angular/common';
 import { CookieService } from 'ngx-cookie';
 import { CookieModule } from 'ngx-cookie';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Router } from '@angular/router';
+import { Router, provideRouter, Routes } from '@angular/router';
+import { Component } from '@angular/core';
+
+@Component({ standalone: false, template: '' })
+class StubComponent {}
+
+const routes: Routes = [{ path: '**', component: StubComponent }];
 import { ForgerockAuthRedirectOIDCService } from '../../oidc.service';
 import { ForgerockOIDCConfigToken } from '../../tokens';
 import {
@@ -30,8 +35,10 @@ describe('LogoutEffect', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, CookieModule.forRoot(), RouterTestingModule.withRoutes([]), CommonModule],
+      imports: [HttpClientTestingModule, CookieModule.forRoot(), CommonModule],
+      declarations: [StubComponent],
       providers: [
+        provideRouter(routes),
         {
           provide: ForgerockOIDCConfigToken,
           useValue: {
@@ -50,8 +57,8 @@ describe('LogoutEffect', () => {
   });
 
   it('should return Success action', waitForAsync(() => {
-    ApiServiceSpy = spyOn(apiService, 'logout').and.returnValue(of(true));
-    routerSpy = spyOn(router, 'navigate');
+    ApiServiceSpy = jest.spyOn(apiService, 'logout').mockReturnValue(of(true));
+    routerSpy = jest.spyOn(router, 'navigate');
 
     actions = new ReplaySubject(1);
     actions.next(new ForgerockOIDCLogoutRequestAction());
@@ -64,7 +71,7 @@ describe('LogoutEffect', () => {
   }));
 
   it('should return Success action', waitForAsync(() => {
-    ApiServiceSpy = spyOn(apiService, 'logout').and.returnValue(throwError('eee'));
+    ApiServiceSpy = jest.spyOn(apiService, 'logout').mockReturnValue(throwError('eee'));
 
     actions = new ReplaySubject(1);
     actions.next(new ForgerockOIDCLogoutRequestAction());

--- a/secure-api-gateway-ob-uk-ui-rcs/jest.config.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/jest.config.js
@@ -2,7 +2,6 @@ module.exports = {
   preset: 'jest-preset-angular',
   resolver: '<rootDir>/jest.resolver.js',
   testPathIgnorePatterns: ['/node_modules/', '/src/test\\.ts$'],
-  testRunner: 'jest-jasmine2',
   transform: {
     '^.+\\.(ts|js|mjs|html|svg)$': ['jest-preset-angular', {
       stringifyContentPathRegex: '\\.(html|svg)$',

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/account/account.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/account/account.component.spec.ts
@@ -50,7 +50,7 @@ describe('app:rcs AccountComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
     fixture.detectChanges();
@@ -62,7 +62,7 @@ describe('app:rcs AccountComponent', () => {
   });
 
   it('should emit formSubmit decision deny', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit(false);
     fixture.detectChanges();
@@ -74,7 +74,7 @@ describe('app:rcs AccountComponent', () => {
   });
 
   it('should emit formSubmit decision allow', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit(true);
     fixture.detectChanges();

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/consent.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/consent.component.spec.ts
@@ -1,7 +1,7 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { StoreModule } from '@ngrx/store';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
@@ -32,7 +32,6 @@ describe('app:bank ConsentComponent', () => {
       declarations: [ConsentComponent, DynamicComponent],
       imports: [
         ForgerockSharedModule,
-        RouterTestingModule.withRoutes([]),
         CommonModule,
         MatSharedModule,
         TranslateSharedModule,
@@ -46,7 +45,7 @@ describe('app:bank ConsentComponent', () => {
         AccountSelectionComponentModule,
         AccountCheckboxModule
       ],
-      providers: [ApiService]
+      providers: [provideRouter([]), ApiService]
     }).compileComponents();
   }));
 
@@ -54,7 +53,7 @@ describe('app:bank ConsentComponent', () => {
     fixture = TestBed.createComponent(ConsentComponent);
     component = fixture.componentInstance;
     apiService = fixture.debugElement.injector.get(ApiService);
-    postConsentDecisionSpy = spyOn(apiService, 'postConsentDecision').and.callThrough();
+    postConsentDecisionSpy = jest.spyOn(apiService, 'postConsentDecision');
 
     fixture.detectChanges();
   });

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/customer-info/customer-info.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/customer-info/customer-info.component.spec.ts
@@ -46,7 +46,7 @@ describe('CustomerInfoComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
     fixture.detectChanges();
@@ -57,7 +57,7 @@ describe('CustomerInfoComponent', () => {
   });
 
   it('should emit formSubmit decision deny', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit(false);
     fixture.detectChanges();
@@ -68,7 +68,7 @@ describe('CustomerInfoComponent', () => {
   });
 
   it('should emit formSubmit decision allow', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit(true);
     fixture.detectChanges();

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.spec.ts
@@ -65,7 +65,7 @@ describe('app:bank DomesticPaymentComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -89,7 +89,7 @@ describe('app:bank DomesticPaymentComponent', () => {
         }
       ]
     };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -114,7 +114,7 @@ describe('app:bank DomesticPaymentComponent', () => {
         }
       ]
     };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.spec.ts
@@ -63,7 +63,7 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -87,7 +87,7 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -112,7 +112,7 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.spec.ts
@@ -64,7 +64,7 @@ describe('app:bank DomesticStandingOrderComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -89,7 +89,7 @@ describe('app:bank DomesticStandingOrderComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -115,7 +115,7 @@ describe('app:bank DomesticStandingOrderComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.spec.ts
@@ -70,7 +70,7 @@ describe('app:bank FilePaymentComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -95,7 +95,7 @@ describe('app:bank FilePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -121,7 +121,7 @@ describe('app:bank FilePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/funds-confirmation/funds-confirmation.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/funds-confirmation/funds-confirmation.component.spec.ts
@@ -110,7 +110,7 @@ describe('app:bank FundsConfirmationComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -123,7 +123,7 @@ describe('app:bank FundsConfirmationComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
 
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     component.response = responseObject
@@ -139,7 +139,7 @@ describe('app:bank FundsConfirmationComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
 
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     component.response = responseObject

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.spec.ts
@@ -64,7 +64,7 @@ describe('app:bank InternationalPaymentComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -89,7 +89,7 @@ describe('app:bank InternationalPaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -115,7 +115,7 @@ describe('app:bank InternationalPaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.spec.ts
@@ -63,7 +63,7 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -88,7 +88,7 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -114,7 +114,7 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.spec.ts
@@ -64,7 +64,7 @@ describe('app:bank InternationalStandingOrderComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -89,7 +89,7 @@ describe('app:bank InternationalStandingOrderComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -115,7 +115,7 @@ describe('app:bank InternationalStandingOrderComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.spec.ts
@@ -64,7 +64,7 @@ describe('app:bank SinglePaymentComponent', () => {
   });
 
   it('should emit formSubmit decision deny by default', () => {
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
 
     component.submit();
 
@@ -89,7 +89,7 @@ describe('app:bank SinglePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
@@ -115,7 +115,7 @@ describe('app:bank SinglePaymentComponent', () => {
       }
    ]
 };
-    spyOn(component.formSubmit, 'emit');
+    jest.spyOn(component.formSubmit, 'emit');
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);


### PR DESCRIPTION
## Summary

Phase 2 of the maintainability plan — no production code touched, only test infrastructure.

- **Drop `jest-jasmine2` testRunner** (`jest.config.js` in both projects) — deprecated in jest 30, scheduled for removal in jest 32. Falls back to `jest-circus`, the default runner since jest 27.
- **`RouterTestingModule` → `provideRouter`** (8 spec files) — `RouterTestingModule` is deprecated since Angular 14. Replaced with `provideRouter([])` in `providers`. One spec (`logout.spec.ts`) required a wildcard route because the effect navigates to `/session-lost`.
- **`spyOn` / `.and.returnValue` → `jest.spyOn` / `.mockReturnValue`** (15 spec files) — jasmine globals are not available with `jest-circus`. All jasmine spy API calls migrated to the equivalent jest API.

## Test plan

- [x] `common`: `npm test` — 69 tests pass (16 suites)
- [x] `rcs`: `npm test` — 49 tests pass (14 suites)