### PR TITLE
feat(maintainability): migrate constructor DI to inject() function (phase 5)

### DIFF
--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-details/forgerock-auth-details.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-details/forgerock-auth-details.component.ts
@@ -6,7 +6,8 @@ import {
   Output,
   EventEmitter,
   OnChanges,
-  SimpleChanges
+  SimpleChanges,
+  inject
 } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import _get from 'lodash-es/get';
@@ -23,13 +24,14 @@ import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockAuthDetailsComponent implements OnInit, OnChanges {
+  private readonly configService = inject(ForgerockConfigService);
   @Input() user: IUser;
   @Input() isLoading = false;
   @Output() formSubmit = new EventEmitter<ApiRequest.IUserUpdateBody>();
   formGroup: FormGroup;
   isDisabled: boolean;
 
-  constructor(private configService: ForgerockConfigService) {
+  constructor() {
     this.isDisabled = this.configService.get('featureFlags.disableProfileForm', false);
   }
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-details/forgerock-auth-details.container.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-details/forgerock-auth-details.container.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
@@ -25,10 +25,11 @@ import { ApiRequest } from '../../models';
   `
 })
 export class ForgerockAuthDetailsContainer implements OnInit {
+  private readonly store = inject<Store<IState>>(Store);
   user$: Observable<IUser>;
   isLoading$: Observable<boolean>;
 
-  constructor(private store: Store<IState>) {
+  constructor() {
     this.user$ = this.store.pipe(select(selectUser));
     this.isLoading$ = this.store.pipe(select(selectIsUpdateSubmitting));
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/directives/dynamic-field.directive.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/directives/dynamic-field.directive.ts
@@ -5,7 +5,8 @@ import {
   OnChanges,
   OnInit,
   Type,
-  ViewContainerRef
+  ViewContainerRef,
+  inject
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import debug from 'debug';
@@ -38,6 +39,7 @@ const components: { [type: string]: Type<Field> } = {
   selector: '[dynamicField]'
 })
 export class DynamicFieldDirective implements Field, OnChanges, OnInit {
+  private readonly container = inject(ViewContainerRef);
   @Input()
   config: ICallback;
   @Input()
@@ -46,8 +48,6 @@ export class DynamicFieldDirective implements Field, OnChanges, OnInit {
   group: FormGroup;
 
   component: ComponentRef<Field>;
-
-  constructor(private container: ViewContainerRef) {}
 
   ngOnChanges() {
     if (this.component) {

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/directives/programmatic-input-fire-event.directive.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/directives/programmatic-input-fire-event.directive.ts
@@ -1,13 +1,15 @@
-import { Directive, ElementRef, Renderer2, OnInit } from '@angular/core';
+import { Directive, ElementRef, Renderer2, OnInit, inject } from '@angular/core';
 
 @Directive({
   standalone: false,
   selector: '[programmaticInputFireEvent]'
 })
 export class ProgrammaticInputFireEventDirective implements OnInit {
+  private readonly elementRef = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
   nativeElement: HTMLElement;
 
-  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+  constructor() {
     this.nativeElement = this.elementRef.nativeElement;
   }
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/dynamic-inputs/form-dialog.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/dynamic-inputs/form-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
@@ -15,7 +15,8 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
   `
 })
 export class FormDialogComponent {
-  constructor(public dialogRef: MatDialogRef<FormDialogComponent>, @Inject(MAT_DIALOG_DATA) public data: { reason: string; message: string }) {}
+  public readonly dialogRef = inject<MatDialogRef<FormDialogComponent>>(MatDialogRef);
+  public readonly data = inject<{ reason: string; message: string }>(MAT_DIALOG_DATA);
 
   onNoClick(): void {
     this.dialogRef.close();

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/dynamic-inputs/redirect-callback.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/dynamic-inputs/redirect-callback.component.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 import { Field, ICallback } from '../../../models';
@@ -14,14 +14,14 @@ import { ActivatedRoute, Params } from '@angular/router';
   `
 })
 export class RedirectCallbackComponent implements Field, OnInit {
+  protected readonly route = inject(ActivatedRoute);
+  private readonly conf = inject(ForgerockConfigService);
   authId: string;
   config: ICallback;
   group: FormGroup;
   redirectUrl: string;
   redirectMethod: string;
   trackingCookie: boolean;
-
-  constructor(protected route: ActivatedRoute, private conf: ForgerockConfigService) {}
 
   ngOnInit() {
     this.route.queryParams.subscribe((params: Params) => {

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/forgerock-auth-login.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/forgerock-auth-login.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import debug from 'debug';
@@ -35,18 +35,17 @@ const log = debug('ForgerockAuthLogin:ForgerockAuthLoginComponent');
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockAuthLoginComponent implements OnInit {
+  private readonly api = inject(ForgerockAuthApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly route = inject(ActivatedRoute);
+  private readonly messages = inject(ForgerockMessagesService);
+  private readonly configService = inject(ForgerockConfigService);
   response: ApiReponses.AuthLoginResponse;
   error: Error;
   client: IConfigClient;
   disableRegistration: boolean;
 
-  constructor(
-    private api: ForgerockAuthApiService,
-    private cdr: ChangeDetectorRef,
-    private route: ActivatedRoute,
-    private messages: ForgerockMessagesService,
-    private configService: ForgerockConfigService
-  ) {
+  constructor() {
     this.client = this.configService.get('client');
     this.disableRegistration = this.configService.get('featureFlags.disableRegistration', false);
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/authenticator-push4.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/authenticator-push4.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { StagesParentComponent } from './stages.parent.component';
@@ -25,9 +25,7 @@ import { StagesParentComponent } from './stages.parent.component';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AuthenticatorPush4Component extends StagesParentComponent implements OnInit {
-  constructor(private sanitizer: DomSanitizer) {
-    super();
-  }
+  private readonly sanitizer = inject(DomSanitizer);
 
   ngOnInit() {
     super.ngOnInit();

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/exchance-code.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/exchance-code.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 
 import { StagesParentComponent } from './stages.parent.component';
 import { ActivatedRoute, Params } from '@angular/router';
@@ -12,13 +12,10 @@ import { ActivatedRoute, Params } from '@angular/router';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExchanceCodeComponent extends StagesParentComponent implements OnInit {
+  protected readonly route = inject(ActivatedRoute);
   code: string;
   state: string;
   authId;
-
-  constructor(protected route: ActivatedRoute) {
-    super();
-  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/stages.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-login/stages/stages.component.ts
@@ -7,7 +7,8 @@ import {
   Output,
   SimpleChanges,
   ViewChild,
-  ViewContainerRef
+  ViewContainerRef,
+  inject
 } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import debug from 'debug';
@@ -37,14 +38,12 @@ const log = debug('ForgerockAuthLogin:StagesComponent');
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class StagesComponent implements OnChanges {
+  protected readonly route = inject(ActivatedRoute);
   @Input() response: ApiReponses.AuthLoginResponse;
   @Input() client: IConfigClient;
   @Output() formSubmit: EventEmitter<unknown> = new EventEmitter<unknown>();
   @ViewChild('dynamicTarget', { read: ViewContainerRef, static: true })
   dynamicTarget: ViewContainerRef;
-
-  constructor(protected route: ActivatedRoute) {}
-
 
   ngOnChanges(changes: SimpleChanges) {
     const authId = localStorage.getItem('AUTH_ID');

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-oauth2-authorize/forgerock-auth-oauth2-authorize.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-oauth2-authorize/forgerock-auth-oauth2-authorize.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse, HttpClient, HttpHeaders } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
@@ -41,17 +41,15 @@ import { encodeQueryData, replaceURLOrigin } from '@secureapigateway/secure-api-
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockAuthOauth2AuthorizeComponent implements OnInit {
+  private readonly api = inject(ForgerockAuthApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly route = inject(ActivatedRoute);
+  private readonly http = inject(HttpClient);
+  private readonly router = inject(Router);
+  private readonly configService = inject(ForgerockConfigService);
+
   public isLoading = false;
   public error = '';
-
-  constructor(
-    private api: ForgerockAuthApiService,
-    private cdr: ChangeDetectorRef,
-    private route: ActivatedRoute,
-    private http: HttpClient,
-    private router: Router,
-    private configService: ForgerockConfigService
-  ) {}
 
   async ngOnInit() {
     try {

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-password/forgerock-auth-password.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-password/forgerock-auth-password.component.ts
@@ -6,7 +6,8 @@ import {
   Output,
   EventEmitter,
   OnChanges,
-  SimpleChanges
+  SimpleChanges,
+  inject
 } from '@angular/core';
 import { AbstractControl, FormGroup, FormControl, Validators, ValidatorFn, ValidationErrors } from '@angular/forms';
 import _get from 'lodash-es/get';
@@ -40,13 +41,15 @@ export const RegistrationValidator: ValidatorFn = (control: AbstractControl): Va
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockAuthPasswordComponent implements OnInit, OnChanges {
+  private readonly configService = inject(ForgerockConfigService);
+
   @Input() user: IUser;
   @Input() isLoading = false;
   @Output() formSubmit = new EventEmitter<ApiRequest.IUserPasswordUpdateBody>();
   formGroup: FormGroup;
   isDisabled: boolean;
 
-  constructor(private configService: ForgerockConfigService) {
+  constructor() {
     this.isDisabled = this.configService.get('featureFlags.disablePasswordForm', false);
   }
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-password/forgerock-auth-password.container.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-password/forgerock-auth-password.container.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
@@ -25,10 +25,12 @@ import { ApiRequest } from '../../models';
   `
 })
 export class ForgerockAuthPasswordContainer implements OnInit {
+  private readonly store = inject(Store<IState>);
+
   user$: Observable<IUser>;
   isLoading$: Observable<boolean>;
 
-  constructor(private store: Store<IState>) {
+  constructor() {
     this.user$ = this.store.pipe(select(selectUser));
     this.isLoading$ = this.store.pipe(select(selectIsPasswordSubmitting));
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-profile/forgerock-auth-profile.container.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-profile/forgerock-auth-profile.container.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
@@ -17,10 +17,12 @@ import { first } from 'rxjs/operators';
   `
 })
 export class ProfileContainerComponent implements OnInit {
+  private readonly store = inject(Store<IState>);
+
   userFullName$: Observable<string>;
   username$: Observable<string>;
 
-  constructor(private store: Store<IState>) {
+  constructor() {
     this.userFullName$ = this.store.pipe(select(selectFullName));
     this.username$ = this.store.pipe(select(selectUsername));
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-register/forgerock-auth-register.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-auth-register/forgerock-auth-register.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
@@ -30,18 +30,18 @@ function validateLowercase(c: FormControl) {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockAuthRegisterComponent implements OnInit {
+  private readonly api = inject(ForgerockAuthApiService);
+  private readonly messages = inject(ForgerockMessagesService);
+  private readonly dialog = inject(MatDialog);
+  private readonly translate = inject(TranslateService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly configService = inject(ForgerockConfigService);
+
   formGroup: FormGroup;
   disableRegistration: boolean;
 
-  constructor(
-    private api: ForgerockAuthApiService,
-    private messages: ForgerockMessagesService,
-    private dialog: MatDialog,
-    private translate: TranslateService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private configService: ForgerockConfigService
-  ) {
+  constructor() {
     this.disableRegistration = this.configService.get('featureFlags.disableRegistration', false);
   }
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-toolbar-menu/forgerock-toolbar-menu.container.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/components/forgerock-toolbar-menu/forgerock-toolbar-menu.container.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store, select } from '@ngrx/store';
 
@@ -28,10 +28,12 @@ import { IState } from '../../store/models';
   ]
 })
 export class ForgerockToolbarMenuContainer {
+  private readonly store = inject(Store<IState>);
+
   connected$: Observable<boolean>;
   username$: Observable<string>;
 
-  constructor(private store: Store<IState>) {
+  constructor() {
     this.connected$ = this.store.pipe(select(selectConnected));
     this.username$ = this.store.pipe(select(selectFullName));
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/forgerock-auth-api/forgerock-auth-api.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/forgerock-auth-api/forgerock-auth-api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { catchError, map } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
@@ -11,7 +11,9 @@ import { Params, Router } from '@angular/router';
   providedIn: 'root'
 })
 export class ForgerockAuthApiService {
-  constructor(private http: HttpClient, private configService: ForgerockConfigService, private router: Router) {}
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ForgerockConfigService);
+  private readonly router = inject(Router);
 
   get sessionInfoUrl() {
     return `${this.configService.get('authenticationServer')}/json/sessions?_action=getSessionInfo`;

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/guards/isconnected-guard.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/guards/isconnected-guard.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router, NavigationExtras } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { Store } from '@ngrx/store';
@@ -18,13 +18,11 @@ const log = debug('IsConnectedGuard');
   providedIn: 'root'
 })
 export abstract class IsConnectedGuard implements CanActivate {
-  constructor(
-    protected api: ForgerockAuthApiService,
-    protected router: Router,
-    protected store: Store<IState>,
-    protected configService: ForgerockConfigService,
-    protected messages: ForgerockMessagesService
-  ) {}
+  protected readonly api = inject(ForgerockAuthApiService);
+  protected readonly router = inject(Router);
+  protected readonly store = inject(Store<IState>);
+  protected readonly configService = inject(ForgerockConfigService);
+  protected readonly messages = inject(ForgerockMessagesService);
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
     log('canActivate', route, state);

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/store/effects/logout.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/store/effects/logout.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
@@ -9,6 +9,10 @@ import { LogoutSuccessAction, LogoutErrorAction, logoutTypes } from '../reducers
 
 @Injectable()
 export class LogoutEffects {
+  private readonly api = inject(ForgerockAuthApiService);
+  private readonly actions$ = inject(Actions);
+  private readonly router = inject(Router);
+
   request$ = createEffect(() =>
     this.actions$.pipe(
       ofType(logoutTypes.LOGOUT_REQUEST),
@@ -25,6 +29,4 @@ export class LogoutEffects {
       )
     )
   );
-
-  constructor(private api: ForgerockAuthApiService, private actions$: Actions, private router: Router) {}
 }

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/store/effects/session.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/store/effects/session.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
@@ -9,6 +9,9 @@ import { ForgerockAuthApiService } from '../../forgerock-auth-api/forgerock-auth
 
 @Injectable()
 export class SessionEffects {
+  private readonly api = inject(ForgerockAuthApiService);
+  private readonly actions$ = inject(Actions);
+
   request$ = createEffect(() =>
     this.actions$.pipe(
       ofType(sessionTypes.SESSION_REQUEST),
@@ -20,6 +23,4 @@ export class SessionEffects {
       )
     )
   );
-
-  constructor(private api: ForgerockAuthApiService, private actions$: Actions) {}
 }

--- a/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/store/effects/user.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/authentication/src/lib/store/effects/user.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of, throwError } from 'rxjs';
@@ -14,6 +14,12 @@ import { ForgerockMessagesService } from '@secureapigateway/secure-api-gateway-o
 
 @Injectable()
 export class UserEffects {
+  private readonly api = inject(ForgerockAuthApiService);
+  private readonly actions$ = inject(Actions);
+  private readonly store = inject(Store<IState>);
+  private readonly message = inject(ForgerockMessagesService);
+  private readonly translate = inject(TranslateService);
+
   getProfile$ = createEffect(() =>
     this.actions$.pipe(
       ofType(userTypes.USER_GET_REQUEST),
@@ -69,12 +75,4 @@ export class UserEffects {
       )
     )
   );
-
-  constructor(
-    private api: ForgerockAuthApiService,
-    private actions$: Actions,
-    private store: Store<IState>,
-    private message: ForgerockMessagesService,
-    private translate: TranslateService
-  ) {}
 }

--- a/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/file-upload/file-upload.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/file-upload/file-upload.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UploadEvent, FileSystemFileEntry } from 'ngx-file-drop';
 
 import { ForgerockMessagesService } from 'forgerock/src/app/services/forgerock-messages/forgerock-messages.service';
@@ -16,9 +16,9 @@ export interface FileUploadChangeObject {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileUploadComponent implements OnInit {
-  @Output() change = new EventEmitter<FileUploadChangeObject>();
+  private readonly message = inject(ForgerockMessagesService);
 
-  constructor(private message: ForgerockMessagesService) {}
+  @Output() change = new EventEmitter<FileUploadChangeObject>();
 
   ngOnInit() {}
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/palette-background/palette-background.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/palette-background/palette-background.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, inject } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
@@ -13,6 +13,8 @@ import { filter } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PaletteBackgroundComponent implements OnInit, OnDestroy {
+  private readonly cssVarsService = inject(ForgerockCssVarsService);
+
   formSubscription: Subscription;
   themesControl = new FormControl('theme');
   themeNames: string[] = ['light', 'dark'];
@@ -20,8 +22,6 @@ export class PaletteBackgroundComponent implements OnInit, OnDestroy {
   backgroundThemeObject: { [key: string]: IPalette };
   foregroundPaletteProps: string[];
   backgroundPaletteProps: string[];
-
-  constructor(private cssVarsService: ForgerockCssVarsService) {}
 
   ngOnInit() {
     this.foregroundPaletteProps = this.cssVarsService.getPalettePropsByType('foreground');

--- a/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/palette/palette.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/palette/palette.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input, ChangeDetectionStrategy, inject } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
@@ -13,14 +13,14 @@ import { filter } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PaletteComponent implements OnInit, OnDestroy {
+  private readonly cssVarsService = inject(ForgerockCssVarsService);
+
   @Input() type: IThemeType;
   formSubscription: Subscription;
   themesControl = new FormControl('theme');
   themeNames: string[];
   themeObject: { [key: string]: IPalette };
   paletteProps: string[];
-
-  constructor(private cssVarsService: ForgerockCssVarsService) {}
 
   ngOnInit() {
     this.paletteProps = this.cssVarsService.getPalettePropsByType(this.type);

--- a/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/sidenav/sidenav.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/components/sidenav/sidenav.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import { ForgerockCustomizationService } from 'forgerock/src/app/modules/customization/services/customization.service';
@@ -13,15 +13,13 @@ import { AddLogoAction, AddIconAction, AddFaviconAction } from '../../store/redu
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockCustomizationSidenavComponent implements OnInit {
+  protected readonly store = inject<Store<any>>(Store);
+  private readonly customizationService = inject(ForgerockCustomizationService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
   @Input() disableIcon = false;
   @Input() enable = true;
   isOpened: boolean;
-
-  constructor(
-    protected store: Store<any>,
-    private customizationService: ForgerockCustomizationService,
-    private cdr: ChangeDetectorRef
-  ) {}
 
   ngOnInit() {
     this.customizationService.onOpen().subscribe((isOpened: boolean) => {

--- a/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/services/cssvars.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/services/cssvars.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import _merge from 'lodash-es/merge';
 import _get from 'lodash-es/get';
@@ -67,6 +67,9 @@ const paletteBackgroundProps: string[] = [
   providedIn: 'root'
 })
 export class ForgerockCssVarsService {
+  private readonly _document = inject<any>(DOCUMENT);
+  private readonly _config = inject<ForgerockCustomization>(ForgerockCustomizationToken);
+
   private _init = false;
   private _matPalettes: {
     [key: string]: IPalette;
@@ -83,15 +86,6 @@ export class ForgerockCssVarsService {
   private _matPaletteNames: string[] = [];
   private _foregroundPaletteNames: string[] = [];
   private _backgroundPaletteNames: string[] = [];
-
-  constructor(
-    @Inject(DOCUMENT) private _document: any,
-    @Inject(ForgerockCustomizationToken) private _config: ForgerockCustomization
-  ) {
-    // Keep in case the palette list changes
-    // const cssVars = require('sass-extract-loader!./cssvars.scss');
-    // this.parseScssVars(cssVars.global);
-  }
 
   public get matPalettes() {
     return this._matPalettes;

--- a/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/services/customization.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/common/src/app/modules/customization/services/customization.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import * as fileSaver from 'file-saver';
 import { Store, select } from '@ngrx/store';
@@ -12,13 +12,11 @@ import { take } from 'rxjs/operators';
   providedIn: 'root'
 })
 export class ForgerockCustomizationService {
-  public isOpened$ = new BehaviorSubject<boolean>(false);
+  protected readonly store = inject<Store<any>>(Store);
+  private readonly cssVarsService = inject(ForgerockCssVarsService);
+  private readonly document = inject<any>(DOCUMENT);
 
-  constructor(
-    protected store: Store<any>,
-    private cssVarsService: ForgerockCssVarsService,
-    @Inject(DOCUMENT) private document: any
-  ) {}
+  public isOpened$ = new BehaviorSubject<boolean>(false);
 
   open = async () => {
     await this.cssVarsService.init();

--- a/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-confirm-dialog/src/forgerock-confirm-dialog.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-confirm-dialog/src/forgerock-confirm-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 export interface ConfirmDialogData {
@@ -25,10 +25,8 @@ export interface ConfirmDialogData {
   `
 })
 export class ForgerockConfirmDialogComponent {
-  constructor(
-    public dialogRef: MatDialogRef<ForgerockConfirmDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: ConfirmDialogData
-  ) {}
+  public readonly dialogRef = inject<MatDialogRef<ForgerockConfirmDialogComponent>>(MatDialogRef);
+  public readonly data = inject<ConfirmDialogData>(MAT_DIALOG_DATA);
 
   onNoClick(): void {
     this.dialogRef.close();

--- a/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-favicon/src/forgerock-customer-favicon.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-favicon/src/forgerock-customer-favicon.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { HttpClient } from '@angular/common/http';
+import { SafeHtml } from '@angular/platform-browser';
 
-// import { selectors } from 'forgerock/src/app/modules/customization/store/reducers/files';
-import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/services/forgerock-config';
 import { ForgerockCustomerSVGComponent } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/components/forgerock-customer-svg';
 
 @Component({
@@ -22,15 +18,9 @@ export class ForgerockCustomerFaviconComponent extends ForgerockCustomerSVGCompo
 
   defaultImgSrc = './assets/favicons/safari-pinned-tab.svg';
   declare svg$: Observable<SafeHtml>;
-  // stream$: Observable<string> = this.store.pipe(select(selectors.selectFavicon));
   stream$: Observable<string> = of('');
 
-  constructor(
-    protected store: Store<unknown>,
-    protected configService: ForgerockConfigService,
-    protected sanitizer: DomSanitizer,
-    protected http: HttpClient
-  ) {
-    super(store, configService, sanitizer, http);
+  constructor() {
+    super();
   }
 }

--- a/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-icon/src/forgerock-customer-icon.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-icon/src/forgerock-customer-icon.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit, Input, ChangeDetectionStrategy, HostBinding } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { HttpClient } from '@angular/common/http';
+import { SafeHtml } from '@angular/platform-browser';
 
-import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common//services/forgerock-config';
-// import { selectors } from 'forgerock/src/app/modules/customization/store/reducers/files';
 import { ForgerockCustomerSVGComponent } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/components/forgerock-customer-svg';
 
 @Component({
@@ -40,13 +36,8 @@ export class ForgerockCustomerIconComponent extends ForgerockCustomerSVGComponen
   // stream$: Observable<string> = this.store.pipe(select(selectors.selectIcon));
   stream$: Observable<string> = of('');
 
-  constructor(
-    protected store: Store<unknown>,
-    protected configService: ForgerockConfigService,
-    protected sanitizer: DomSanitizer,
-    protected http: HttpClient
-  ) {
-    super(store, configService, sanitizer, http);
+  constructor() {
+    super();
     this.width = this.configService.get('client.iconWidth', 50) as number;
     this.height = this.configService.get('client.iconHeight', 50) as number;
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-logo/src/forgerock-customer-logo.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-logo/src/forgerock-customer-logo.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { HttpClient } from '@angular/common/http';
+import { SafeHtml } from '@angular/platform-browser';
 
-import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common//services/forgerock-config';
-// import { selectors } from 'forgerock/src/app/modules/customization/store/reducers/files';
 import { ForgerockCustomerSVGComponent } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/components/forgerock-customer-svg';
 
 @Component({
@@ -25,13 +21,8 @@ export class ForgerockCustomerLogoComponent extends ForgerockCustomerSVGComponen
   // stream$: Observable<string> = this.store.pipe(select(selectors.selectLogo));
   stream$: Observable<string> = of('');
 
-  constructor(
-    protected store: Store<unknown>,
-    protected configService: ForgerockConfigService,
-    protected sanitizer: DomSanitizer,
-    protected http: HttpClient
-  ) {
-    super(store, configService, sanitizer, http);
+  constructor() {
+    super();
     this.width = this.configService.get('client.logoWidth', 70) as number;
     this.height = this.configService.get('client.logoHeight', '100%') as string;
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-svg/src/forgerock-customer-svg.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-customer-svg/src/forgerock-customer-svg.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
@@ -16,18 +16,16 @@ import { HttpClient } from '@angular/common/http';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockCustomerSVGComponent implements OnInit {
+  protected readonly store = inject<Store<unknown>>(Store);
+  protected readonly configService = inject(ForgerockConfigService);
+  protected readonly sanitizer = inject(DomSanitizer);
+  protected readonly http = inject(HttpClient);
+
   defaultImgSrc: string;
   svg$: Observable<SafeHtml>;
   width: number | string;
   height: number | string;
   stream$: Observable<string>;
-
-  constructor(
-    protected store: Store<unknown>,
-    protected configService: ForgerockConfigService,
-    protected sanitizer: DomSanitizer,
-    protected http: HttpClient
-  ) {}
 
   ngOnInit() {
     this.svg$ = this.stream$.pipe(

--- a/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-splitflap/src/forgerock-splitflap-character.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/components/forgerock-splitflap/src/forgerock-splitflap-character.component.ts
@@ -7,7 +7,8 @@ import {
   SimpleChanges,
   HostBinding,
   ChangeDetectorRef,
-  OnDestroy
+  OnDestroy,
+  inject
 } from '@angular/core';
 @Component({
   standalone: false,
@@ -26,6 +27,8 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockSplitFlapCharacterComponent implements OnInit, OnChanges, OnDestroy {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
   @Input() size: string;
   @Input() theme = 'dark';
   @Input() value: string;
@@ -47,8 +50,6 @@ export class ForgerockSplitFlapCharacterComponent implements OnInit, OnChanges, 
     'transition-duration': '0',
     'transition-delay': '0'
   };
-
-  constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
   @HostBinding('class') get class() {
     return `${this.size} ${this.theme}`;

--- a/secure-api-gateway-ob-uk-ui-common/projects/gdpr/src/lib/gdpr.guard.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/gdpr/src/lib/gdpr.guard.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, NavigationExtras } from '@angular/router';
 import { ForgerockGDPRService } from './gdpr.service';
 
@@ -6,7 +6,9 @@ import { ForgerockGDPRService } from './gdpr.service';
   providedIn: 'root'
 })
 export class ForegerockGDPRConsentGuard implements CanActivate {
-  constructor(protected gdprService: ForgerockGDPRService, protected router: Router) {}
+  protected readonly gdprService = inject(ForgerockGDPRService);
+  protected readonly router = inject(Router);
+
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     if (this.gdprService.hasAnswered && !this.gdprService.hasConsented) {

--- a/secure-api-gateway-ob-uk-ui-common/projects/gdpr/src/lib/gdpr.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/gdpr/src/lib/gdpr.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Router, ActivatedRoute, NavigationExtras } from '@angular/router';
 import { NgcCookieConsentService, NgcStatusChangeEvent } from 'ngx-cookieconsent';
 
@@ -8,14 +8,14 @@ import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-
   providedIn: 'root'
 })
 export class ForgerockGDPRService {
+  private readonly configService = inject(ForgerockConfigService);
+  private readonly ccService = inject(NgcCookieConsentService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
   static gdprDeniedPage = 'access-denied';
 
-  constructor(
-    private configService: ForgerockConfigService,
-    private ccService: NgcCookieConsentService,
-    private route: ActivatedRoute,
-    private router: Router
-  ) {
+  constructor() {
     this.ccService.statusChange$.subscribe((event: NgcStatusChangeEvent) => {
       if (event.status === 'allow' && window.location.pathname === '/' + ForgerockGDPRService.gdprDeniedPage) {
         const { returnUrl } = this.route.snapshot.queryParams;
@@ -23,7 +23,7 @@ export class ForgerockGDPRService {
       } else if (event.status === 'deny' && window.location.pathname !== '/' + ForgerockGDPRService.gdprDeniedPage) {
         const options: NavigationExtras = {
           queryParams: {
-            returnUrl: encodeURIComponent(router.routerState.snapshot.url)
+            returnUrl: encodeURIComponent(this.router.routerState.snapshot.url)
           }
         };
         this.router.navigate(['/' + ForgerockGDPRService.gdprDeniedPage], options);

--- a/secure-api-gateway-ob-uk-ui-common/projects/guards/src/lib/can-customer-load.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/guards/src/lib/can-customer-load.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { CanLoad, Route, Router, CanActivate, RouterStateSnapshot, ActivatedRouteSnapshot } from '@angular/router';
 import debug from 'debug';
 
@@ -8,9 +8,12 @@ const log = debug('ForgerockCustomerCanAccessGuard');
 
 @Injectable()
 export class ForgerockCustomerCanAccessGuard implements CanLoad, CanActivate {
+  private readonly router = inject(Router);
+  private readonly configService = inject(ForgerockConfigService);
+
   blacklist: string[];
 
-  constructor(private router: Router, private configService: ForgerockConfigService) {
+  constructor() {
     this.blacklist = this.configService.get('routeDenyList', []);
   }
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/interceptors/src/lib/httpTimeout.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/interceptors/src/lib/httpTimeout.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { timeout } from 'rxjs/operators';
@@ -8,7 +8,7 @@ export const DEFAULT_HTTP_TIMEOUT = 30000;
 
 @Injectable()
 export class TimeoutInterceptor implements HttpInterceptor {
-  constructor(@Inject(FORGEROCK_HTTP_TIMEOUT_TOKEN) protected appTimeout: number) {}
+  protected readonly appTimeout = inject(FORGEROCK_HTTP_TIMEOUT_TOKEN);
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     // timeout can be changed per call via timeout header

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/navbar/horizontal/style-1/style-1.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/navbar/horizontal/style-1/style-1.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
@@ -12,13 +12,11 @@ import { ForgerockMainLayoutNavigationService } from '../../../../navigation/nav
   encapsulation: ViewEncapsulation.None
 })
 export class NavbarHorizontalStyle1Component implements OnInit, OnDestroy {
+  private readonly _fuseNavigationService = inject(ForgerockMainLayoutNavigationService);
+
   navigation: unknown;
 
-  private _unsubscribeAll: Subject<void>;
-
-  constructor(private _fuseNavigationService: ForgerockMainLayoutNavigationService) {
-    this._unsubscribeAll = new Subject<void>();
-  }
+  private _unsubscribeAll: Subject<void> = new Subject<void>();
 
   ngOnInit(): void {
     this._fuseNavigationService.onNavigationChanged

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/navbar/navbar.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, Renderer2, ViewEncapsulation, OnInit, OnDestroy } from '@angular/core';
+import { Component, ElementRef, Input, Renderer2, ViewEncapsulation, OnInit, OnDestroy, inject } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
@@ -13,17 +13,13 @@ import { IForgerockMainLayoutConfig } from '../../models';
   encapsulation: ViewEncapsulation.None
 })
 export class NavbarComponent implements OnInit, OnDestroy {
+  private readonly _elementRef = inject(ElementRef);
+  private readonly _renderer = inject(Renderer2);
+  private readonly configService = inject(ForgerockMainLayoutConfigService);
+
   _variant = 'vertical-style-1';
   public layoutConfig: IForgerockMainLayoutConfig;
-  private _unsubscribeAll: Subject<void>;
-
-  constructor(
-    private _elementRef: ElementRef,
-    private _renderer: Renderer2,
-    private configService: ForgerockMainLayoutConfigService
-  ) {
-    this._unsubscribeAll = new Subject<void>();
-  }
+  private _unsubscribeAll: Subject<void> = new Subject<void>();
 
   get variant(): string {
     return this._variant;

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/navbar/vertical/style-1/style-1.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/navbar/vertical/style-1/style-1.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
@@ -16,22 +16,21 @@ import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-
   encapsulation: ViewEncapsulation.None
 })
 export class NavbarVerticalStyle1Component implements OnInit, OnDestroy {
+  private readonly _fuseConfigService = inject(ForgerockMainLayoutConfigService);
+  private readonly _fuseNavigationService = inject(ForgerockMainLayoutNavigationService);
+  private readonly _fuseSidebarService = inject(ForgerockLayoutSidebarService);
+  private readonly _router = inject(Router);
+  private readonly configService = inject(ForgerockConfigService);
+
   fuseConfig: unknown;
   // fusePerfectScrollbarUpdateTimeout: unknown;
   navigation: unknown;
   clientName: string;
 
   // private _fusePerfectScrollbar: FusePerfectScrollbarDirective;
-  private _unsubscribeAll: Subject<void>;
+  private _unsubscribeAll: Subject<void> = new Subject<void>();
 
-  constructor(
-    private _fuseConfigService: ForgerockMainLayoutConfigService,
-    private _fuseNavigationService: ForgerockMainLayoutNavigationService,
-    private _fuseSidebarService: ForgerockLayoutSidebarService,
-    private _router: Router,
-    private configService: ForgerockConfigService
-  ) {
-    this._unsubscribeAll = new Subject<void>();
+  constructor() {
     this.clientName = this.configService.get('client.name') as string;
   }
   /**

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/toolbar/toolbar.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/components/toolbar/toolbar.component.ts
@@ -6,7 +6,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ComponentRef,
-  Inject
+  inject
 } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
 
@@ -22,6 +22,10 @@ import { ForgerockMainLayoutComponentsToken } from '../../tokens';
   styleUrls: ['./toolbar.component.scss']
 })
 export class ToolbarComponent implements OnInit, OnDestroy {
+  private readonly _fuseSidebarService = inject(ForgerockLayoutSidebarService);
+  private readonly configService = inject(ForgerockConfigService);
+  private readonly _components = inject<IForgerockMainLayoutComponents>(ForgerockMainLayoutComponentsToken);
+
   @Input() type: 'horizontal' | 'vertical' = 'vertical';
   @ViewChild('dynamicTarget', { read: ViewContainerRef, static: true })
   dynamicTarget: ViewContainerRef;
@@ -31,15 +35,9 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   clientName: string;
   componentRef: ComponentRef<unknown>;
 
-  private _unsubscribeAll: Subject<void>;
+  private _unsubscribeAll: Subject<void> = new Subject<void>();
 
-  constructor(
-    private _fuseSidebarService: ForgerockLayoutSidebarService,
-    private configService: ForgerockConfigService,
-    @Inject(ForgerockMainLayoutComponentsToken)
-    private _components: IForgerockMainLayoutComponents
-  ) {
-    this._unsubscribeAll = new Subject<void>();
+  constructor() {
     this.clientName = this.configService.get('client.name') as string;
   }
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/main-layout.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/main-layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, OnDestroy, Inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, OnDestroy, inject } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -30,17 +30,17 @@ import { IForgerockMainLayoutConfig, IForgerockMainLayoutNavigation } from './mo
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ForgerockMainLayoutComponent implements OnDestroy {
+  private readonly configService = inject(ForgerockMainLayoutConfigService);
+  private readonly navigationService = inject(ForgerockMainLayoutNavigationService);
+  private readonly router = inject(Router);
+  private readonly document = inject(DOCUMENT);
+
   config$: Observable<IForgerockMainLayoutConfig>;
   navigation$: Observable<{ key: string; navigation: IForgerockMainLayoutNavigation[] }>;
   private _unsubscribeAll: Subject<void> = new Subject<void>();
   private latestPathnameClass = '';
 
-  constructor(
-    private configService: ForgerockMainLayoutConfigService,
-    private navigationService: ForgerockMainLayoutNavigationService,
-    private router: Router,
-    @Inject(DOCUMENT) private document: Document
-  ) {
+  constructor() {
     this.config$ = this.configService.config;
     this.navigation$ = this.navigationService.onNavigationChanged;
     this.router.events.pipe(takeUntil(this._unsubscribeAll)).subscribe(val => {

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/main-layout.config.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/main-layout.config.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
 import { DOCUMENT } from '@angular/common';
 import { Platform } from '@angular/cdk/platform';
@@ -15,17 +15,16 @@ import { IForgerockMainLayoutConfig } from './models';
   providedIn: 'root'
 })
 export class ForgerockMainLayoutConfigService {
+  private readonly _platform = inject(Platform);
+  private readonly _router = inject(Router);
+  private readonly _document = inject(DOCUMENT);
+  private readonly _config = inject<IForgerockMainLayoutConfig>(ForgerockMainLayoutConfigToken);
+
   private _configSubject: BehaviorSubject<IForgerockMainLayoutConfig>;
   private readonly _defaultConfig: IForgerockMainLayoutConfig;
 
-  constructor(
-    private _platform: Platform,
-    private _router: Router,
-    @Inject(DOCUMENT) private _document: Document,
-    @Inject(ForgerockMainLayoutConfigToken)
-    private _config: IForgerockMainLayoutConfig
-  ) {
-    this._defaultConfig = _config;
+  constructor() {
+    this._defaultConfig = this._config;
 
     this._init();
   }

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/navigation/horizontal/collapsable/collapsable.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/navigation/horizontal/collapsable/collapsable.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, HostListener, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, HostBinding, HostListener, Input, OnDestroy, OnInit, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -12,6 +12,8 @@ import { IForgerockMainLayoutConfig, IForgerockMainLayoutNavigationItem } from '
   styleUrls: ['./collapsable.component.scss']
 })
 export class FuseNavHorizontalCollapsableComponent implements OnInit, OnDestroy {
+  private readonly _fuseConfigService = inject(ForgerockMainLayoutConfigService);
+
   @HostBinding('class')
   classes = 'nav-collapsable nav-item';
 
@@ -22,12 +24,7 @@ export class FuseNavHorizontalCollapsableComponent implements OnInit, OnDestroy 
   isOpen = false;
 
   // Private
-  private _unsubscribeAll: Subject<void>;
-
-  constructor(private _fuseConfigService: ForgerockMainLayoutConfigService) {
-    // Set the private defaults
-    this._unsubscribeAll = new Subject<void>();
-  }
+  private _unsubscribeAll: Subject<void> = new Subject<void>();
 
   /**
    * Open

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/navigation/navigation.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/navigation/navigation.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import debug from 'debug';
@@ -17,20 +17,17 @@ const log = debug('ForgerockMainLayoutNavigationComponent');
   encapsulation: ViewEncapsulation.None
 })
 export class ForgerockMainLayoutNavigationComponent implements OnInit {
+  private readonly _fuseNavigationService = inject(ForgerockMainLayoutNavigationService);
+  private readonly configService = inject(ForgerockConfigService);
+
   @Input()
   layout = 'vertical';
 
   @Input()
   navigation: IForgerockMainLayoutNavigationItem[];
 
-  private _unsubscribeAll: Subject<void>;
+  private _unsubscribeAll: Subject<void> = new Subject<void>();
 
-  constructor(
-    private _fuseNavigationService: ForgerockMainLayoutNavigationService,
-    private configService: ForgerockConfigService
-  ) {
-    this._unsubscribeAll = new Subject<void>();
-  }
   ngOnInit(): void {
     this.navigation = this.filterNavigationWithRouteDenyList(
       this.navigation || this._fuseNavigationService.getCurrentNavigation()

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/navigation/navigation.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/navigation/navigation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { IForgerockMainLayoutNavigationItem, IForgerockMainLayoutNavigations } from '../models';
@@ -9,6 +9,9 @@ import { ForgerockConfigService } from '@secureapigateway/secure-api-gateway-ob-
   providedIn: 'root'
 })
 export class ForgerockMainLayoutNavigationService {
+  private readonly _navigations = inject<IForgerockMainLayoutNavigations>(ForgerockMainLayoutNavigationsToken);
+  private readonly configService = inject(ForgerockConfigService);
+
   onItemCollapsed: Subject<IForgerockMainLayoutNavigationItem>;
   onItemCollapseToggled: Subject<void>;
 
@@ -22,11 +25,7 @@ export class ForgerockMainLayoutNavigationService {
   /**
    * Constructor
    */
-  constructor(
-    @Inject(ForgerockMainLayoutNavigationsToken)
-    private _navigations: IForgerockMainLayoutNavigations,
-    private configService: ForgerockConfigService
-  ) {
+  constructor() {
     this.onItemCollapsed = new Subject<IForgerockMainLayoutNavigationItem>();
     this.onItemCollapseToggled = new Subject<void>();
 

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/sidebar/match-media.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/sidebar/match-media.service.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 const BREAKPOINTS: Record<string, string> = {
@@ -22,10 +22,12 @@ const BREAKPOINTS: Record<string, string> = {
   providedIn: 'root'
 })
 export class ForegerockLayoutMatchMediaService {
+  private readonly _breakpointObserver = inject(BreakpointObserver);
+
   activeMediaQuery: string;
   onMediaChange: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
-  constructor(private _breakpointObserver: BreakpointObserver) {
+  constructor() {
     this.activeMediaQuery = '';
 
     this._init();

--- a/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/sidebar/sidebar.component.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/layouts/main-layout/src/sidebar/sidebar.component.ts
@@ -11,7 +11,8 @@ import {
   Output,
   Renderer2,
   RendererStyleFlags2,
-  ViewEncapsulation
+  ViewEncapsulation,
+  inject
 } from '@angular/core';
 import { animate, AnimationBuilder, AnimationPlayer, style } from '@angular/animations';
 import { Subject } from 'rxjs';
@@ -29,6 +30,14 @@ import { ForegerockLayoutMatchMediaService } from './match-media.service';
   encapsulation: ViewEncapsulation.None
 })
 export class ForgerockLayoutSidebarComponent implements OnInit, OnDestroy {
+  private readonly _animationBuilder = inject(AnimationBuilder);
+  private readonly _changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly _elementRef = inject(ElementRef);
+  private readonly _fuseConfigService = inject(ForgerockMainLayoutConfigService);
+  private readonly _fuseMatchMediaService = inject(ForegerockLayoutMatchMediaService);
+  private readonly _fuseSidebarService = inject(ForgerockLayoutSidebarService);
+  private readonly _renderer = inject(Renderer2);
+
   @Input() name: string;
 
   @Input() key: string;
@@ -73,15 +82,7 @@ export class ForgerockLayoutSidebarComponent implements OnInit, OnDestroy {
   private _player: AnimationPlayer;
   private _unsubscribeAll: Subject<void>;
 
-  constructor(
-    private _animationBuilder: AnimationBuilder,
-    private _changeDetectorRef: ChangeDetectorRef,
-    private _elementRef: ElementRef,
-    private _fuseConfigService: ForgerockMainLayoutConfigService,
-    private _fuseMatchMediaService: ForegerockLayoutMatchMediaService,
-    private _fuseSidebarService: ForgerockLayoutSidebarService,
-    private _renderer: Renderer2
-  ) {
+  constructor() {
     this.foldedAutoTriggerOnHover = true;
     this.foldedWidth = 64;
     this.foldedChanged = new EventEmitter();

--- a/secure-api-gateway-ob-uk-ui-common/projects/oidc/src/lib/oidc.guard.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/oidc/src/lib/oidc.guard.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { select, Store } from '@ngrx/store';
@@ -16,12 +16,11 @@ const log = debug('guards:IsOIDCConnectedGuard');
   providedIn: 'root'
 })
 export class IsOIDCConnectedGuard implements CanActivate {
-  constructor(
-    protected auth: ForgerockAuthRedirectOIDCService,
-    protected router: Router,
-    protected store: Store<IOIDCModuleState>,
-    protected configService: ForgerockConfigService
-  ) {}
+  protected readonly auth = inject(ForgerockAuthRedirectOIDCService);
+  protected readonly router = inject(Router);
+  protected readonly store = inject<Store<IOIDCModuleState>>(Store);
+  protected readonly configService = inject(ForgerockConfigService);
+
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | boolean {
     let isConnected;

--- a/secure-api-gateway-ob-uk-ui-common/projects/services/forgerock-config/src/forgerock-config.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/services/forgerock-config/src/forgerock-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import _merge from 'lodash-es/merge';
@@ -8,9 +8,10 @@ import _get from 'lodash-es/get';
   providedIn: 'root'
 })
 export class ForgerockConfigService {
+  private readonly http = inject(HttpClient);
+
   private _config: unknown = {};
 
-  constructor(private http: HttpClient) {}
 
   get config() {
     return this._config;

--- a/secure-api-gateway-ob-uk-ui-common/projects/services/forgerock-messages/src/forgerock-messages.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/services/forgerock-messages/src/forgerock-messages.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 const defaultSnackbarOptions = {
@@ -7,7 +7,8 @@ const defaultSnackbarOptions = {
 
 @Injectable()
 export class ForgerockMessagesService {
-  constructor(private snackBar: MatSnackBar) {}
+  private readonly snackBar = inject(MatSnackBar);
+
 
   error(text = 'Something Wrong happened', action = '', options = defaultSnackbarOptions) {
     return this.snackBar.open(text, action, options);

--- a/secure-api-gateway-ob-uk-ui-common/projects/services/forgerock-splashscreen/src/forgerock-splashscreen.service.ts
+++ b/secure-api-gateway-ob-uk-ui-common/projects/services/forgerock-splashscreen/src/forgerock-splashscreen.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { animate, AnimationBuilder, AnimationPlayer, style } from '@angular/animations';
 import { NavigationEnd, Router } from '@angular/router';
@@ -7,14 +7,14 @@ import { NavigationEnd, Router } from '@angular/router';
   providedIn: 'root'
 })
 export class ForgerockSplashscreenService {
+  private readonly _animationBuilder = inject(AnimationBuilder);
+  private readonly _document = inject<Document>(DOCUMENT);
+  private readonly _router = inject(Router);
+
   splashScreenEl: Element;
   player: AnimationPlayer;
   _init = false;
-  constructor(
-    private _animationBuilder: AnimationBuilder,
-    @Inject(DOCUMENT) private _document: Document,
-    private _router: Router
-  ) {}
+
 
   init(): void {
     if (this._init) {

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/app.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component, Inject, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, OnInit, inject} from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Platform } from '@angular/cdk/platform';
 import { TranslateService } from '@ngx-translate/core';
@@ -15,8 +15,30 @@ import {ForgerockMessagesService} from "@secureapigateway/secure-api-gateway-ob-
   `
 })
 export class AppComponent implements OnInit {
+  private readonly document = inject<Document>(DOCUMENT);
+  private readonly splashscreenService = inject(ForgerockSplashscreenService);
+  private readonly translateService = inject(TranslateService);
+  private readonly platform = inject(Platform);
+  private readonly route = inject(ActivatedRoute);
+  private readonly messages = inject(ForgerockMessagesService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
   loading: boolean;
   error: Error;
+
+  constructor() {
+    this.splashscreenService.init();
+
+    this.translateService.addLangs(['en', 'es']);
+    this.translateService.setDefaultLang('en');
+    this.translateService.use(this.translateService.getBrowserLang() || 'en');
+
+    // Add is-mobile class to the body if the platform is mobile
+    if (this.platform.ANDROID || this.platform.IOS) {
+      this.document.body.classList.add('is-mobile');
+    }
+  }
+
     ngOnInit(): void {
       console.log("APP")
       this.route.fragment.subscribe((fragment: string) => {
@@ -40,25 +62,5 @@ export class AppComponent implements OnInit {
       );
 
     }
-  constructor(
-    @Inject(DOCUMENT) private document: Document,
-    private splashscreenService: ForgerockSplashscreenService,
-    private translateService: TranslateService,
-    private platform: Platform,
-    private route: ActivatedRoute,
-    private messages: ForgerockMessagesService,
-    private cdr: ChangeDetectorRef,
-  ) {
-    this.splashscreenService.init();
-
-    this.translateService.addLangs(['en', 'es']);
-    this.translateService.setDefaultLang('en');
-    this.translateService.use(this.translateService.getBrowserLang() || 'en');
-
-    // Add is-mobile class to the body if the platform is mobile
-    if (this.platform.ANDROID || this.platform.IOS) {
-      this.document.body.classList.add('is-mobile');
-    }
-  }
 }
 

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/consent-dev.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/consent-dev.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, inject } from '@angular/core';
 
 import mock1 from './mocks/account-access-consent-details';
 import mock2 from './mocks/vrp-payment-consent-details';
@@ -32,10 +32,11 @@ import { ApiResponses } from '../../types/api';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ConsentDevComponent {
+  private readonly cdr = inject(ChangeDetectorRef);
+
   loading = false;
   mocks: ApiResponses.ConsentDetailsResponse[] = [mock1, mock2, mock3, mock4, mock5, mock6, mock7, mock8, mock9, mock10, mock11];
   mocksDebtorAccount: ApiResponses.ConsentDetailsResponse[] = [mock30, mock31,mock32,mock33,mock34,mock35,mock36,mock37];
-  constructor(private cdr: ChangeDetectorRef) {}
 
 
   onFormSubmit(values: IConsentEventEmitter) {

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/consent.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/consent.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {catchError, retry} from 'rxjs/operators';
 import {Observable, throwError} from 'rxjs';
@@ -19,18 +19,15 @@ import {ConsentDecision} from "../../../../src/app/types/ConsentDecision";
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ConsentComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly api = inject(ApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly messages = inject(ForgerockMessagesService);
+
   loading: boolean;
   error: Error;
   response: ApiResponses.ConsentDetailsResponse;
   consentRequest: string;
-
-  constructor(
-    private route: ActivatedRoute,
-    private api: ApiService,
-    private cdr: ChangeDetectorRef,
-    private messages: ForgerockMessagesService
-  ) {
-  }
 
   ngOnInit() {
     let redirect_uri: string;

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/services/api.service.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/services/api.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 
 import {ForgerockConfigService} from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/services/forgerock-config';
@@ -7,8 +7,9 @@ import {ForgerockConfigService} from '@secureapigateway/secure-api-gateway-ob-uk
   providedIn: 'root'
 })
 export class ApiService {
-  constructor(private http: HttpClient, private configService: ForgerockConfigService) {
-  }
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ForgerockConfigService);
+
 
   getConsentDetails(consentRequest: string) {
     return this.http.post(`${this.configService.get('remoteConsentServer')}/rcs/api/consent/details`, consentRequest, {


### PR DESCRIPTION
## Summary

- Replace constructor parameter injection with `inject()` calls across ~56 files in `common` and `rcs` packages
- Migrated: auth components, services, guards, effects, layout components, customization, SVG components, RCS app components
- Parent class `ForgerockCustomerSVGComponent` migrated first; children updated to use `super()` with no args
- Fix `of` import accidentally dropped from `forgerock-customer-svg.component.ts`
- Fix `forgerock-customer-favicon.component.ts` missed by migration workflow

## Test plan

- [ ] `cd secure-api-gateway-ob-uk-ui-common && npm run build` — all 28 entry points build clean
- [ ] `cd secure-api-gateway-ob-uk-ui-common && npm test` — 16 suites, 69 tests pass
- [ ] `cd secure-api-gateway-ob-uk-ui-rcs && npm test` — 14 suites, 49 tests pass